### PR TITLE
Disable minimal warnings

### DIFF
--- a/templates/linux/cc_toolchain_config.bzl.template
+++ b/templates/linux/cc_toolchain_config.bzl.template
@@ -239,7 +239,7 @@ def _impl(ctx):
 
     minimal_warnings_feature = feature(
         name = "minimal_warnings",
-        enabled = True,
+        enabled = False,
         flag_sets = [
             flag_set(
                 actions = all_compile_actions,
@@ -335,7 +335,7 @@ def _impl(ctx):
 
     pthread_feature = feature(
         name = "use_pthread",
-        enabled = False,
+        enabled = True,
         flag_sets = [
             flag_set(
                 actions = all_link_actions,


### PR DESCRIPTION
Due to still unclear list of flags which we want to support, all warnings features will be disabled by deafault.