### PR TITLE
fix: Add runtime_library_search_directories for QNX dynamic linking

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -35,6 +35,21 @@ cc_test(
     name = "math_lib_test",
     srcs = ["math_lib_test.cpp"],
     deps = [":math_lib"],
+    linkstatic = True,
+)
+
+cc_shared_library(
+    name = "math_lib_shared",
+    shared_lib_name = "libmath_lib.so",
+    deps = [":math_lib"],
+)
+
+cc_test(
+    name = "math_lib_dyn_test",
+    srcs = ["math_lib_test.cpp"],
+    deps = [":math_lib"],
+    dynamic_deps = [":math_lib_shared"],
+    linkstatic = False,
 )
 
 cc_test(

--- a/examples/math_lib_test.cpp
+++ b/examples/math_lib_test.cpp
@@ -12,11 +12,13 @@
 ********************************************************************************/
 
 #include "math_lib.h"
+#include <iostream>
 #include <cassert>
 
 int main() {
     assert(add(2, 3) == 5);
     assert(sub(5, 3) == 2);
+    std::cout << "add(2, 3) = " << add(2, 3) << std::endl;
 
     // Note: sub(3, 5) is NOT tested → coverage will show a missed branch
     return 0;

--- a/templates/qnx/cc_toolchain_config.bzl.template
+++ b/templates/qnx/cc_toolchain_config.bzl.template
@@ -399,6 +399,26 @@ def _impl(ctx):
         ],
     )
 
+    # QNX uses -Wl,-rpath instead of -rpath
+    runtime_library_search_directories_feature = feature(
+        name = "runtime_library_search_directories",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "runtime_library_search_directories",
+                        flag_groups = [
+                            flag_group(
+                                flags = ["-Wl,-rpath,$EXEC_ORIGIN/%{runtime_library_search_directories}"],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
     # The order of the features is relevant, they are applied in this specific order.
     # A command line parameter from a feature at the end of the list will appear
     # after a command line parameter from a feature at the beginning of the list.
@@ -420,6 +440,7 @@ def _impl(ctx):
         use_license_env_info_feautre,
         sdp_env_feature,
         supports_pic_feature,
+        runtime_library_search_directories_feature,
     ]
 
     cxx_builtin_include_directories = [


### PR DESCRIPTION
QNX toolchain requires -Wl,-rpath instead of -rpath for runtime library paths. This enables cc_shared_library and dynamic linking support.

Extend examples for dynamic linking case.