### PR TITLE
Add new QNX package into matrix

### DIFF
--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -116,7 +116,7 @@ gcc.toolchain(
 # *******************************************************************************
 gcc.toolchain(
     name = "score_qcc_toolchain",
-    sdp_version = "8.0.0",
+    sdp_version = "8.0.3",
     target_cpu = "x86_64",
     target_os = "qnx",
     use_default_package = True,

--- a/examples/MODULE.bazel.lock
+++ b/examples/MODULE.bazel.lock
@@ -1044,8 +1044,8 @@
     },
     "@@score_bazel_cpp_toolchains+//extensions:gcc.bzl%gcc": {
       "general": {
-        "bzlTransitiveDigest": "TzOSvaP+r8IKPGkVGHmuI71W8WaOYcU99BEHlKf57XA=",
-        "usagesDigest": "/wUYFdM1xKTzS24yegCMuIO8ZBNPa2xMLcpzqWVKLWw=",
+        "bzlTransitiveDigest": "S0aCuoUpbFzRHKbvk3ttYtQovdrirCqH2Ba203MbQ5o=",
+        "usagesDigest": "unK8CU54SxQZb3A5+/fOy5ZHARy5jWDy5NpNfcCVyNA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1123,7 +1123,7 @@
                 "https://github.com/eclipse-score/inc_os_autosd/releases/download/continuous/autosd-toolchain-x86_64.tar.gz"
               ],
               "build_file": "@@score_bazel_cpp_toolchains+//packages/linux/x86_64/autosd/10.0:autosd.BUILD",
-              "sha256": "525dcca237dfdff3d6c8f3650a0db77a93638141e8c91252544b37447ef9108c",
+              "sha256": "bb5324ec04895eb70b1fcb1787d25856b137962b0381d11f5b3406c37ee15984",
               "strip_prefix": "sysroot"
             }
           },
@@ -1251,7 +1251,7 @@
               "license_info_value": "",
               "license_path": "/opt/score_qnx/license/licenses",
               "sdk_version": "",
-              "sdp_version": "8.0.0",
+              "sdp_version": "8.0.3",
               "tc_compiler_library_search_paths": [],
               "tc_cpu": "x86_64",
               "tc_identifier": "sdp_8.0.0",

--- a/extensions/gcc.bzl
+++ b/extensions/gcc.bzl
@@ -215,10 +215,22 @@ def _create_and_link_sdp(toolchain_info):
     """
     pkg_name = "{}_pkg".format(toolchain_info["name"])
 
+    # Resolve package identifier from original version fields, not the
+    # constraint-remapped tc_identifier. tc_identifier may differ from
+    # the actual version (e.g., sdp 8.0.3 is remapped to 8.0.0 for
+    # platform constraint compatibility), but the version matrix uses
+    # the real version.
+    if toolchain_info["sdk_version"] != "":
+        pkg_identifier = "sdk_{}".format(toolchain_info["sdk_version"])
+    elif toolchain_info["sdp_version"] != "":
+        pkg_identifier = "sdp_{}".format(toolchain_info["sdp_version"])
+    else:
+        pkg_identifier = toolchain_info["tc_identifier"]
+
     matrix_key = "{cpu}-{os}{identifier}{runtime_es}".format(
         cpu = toolchain_info["tc_cpu"],
         os = toolchain_info["tc_os"],
-        identifier = "-{}".format(toolchain_info["tc_identifier"]) if toolchain_info["tc_identifier"] != "" else "",
+        identifier = "-{}".format(pkg_identifier) if pkg_identifier != "" else "",
         runtime_es = "-{}".format(toolchain_info["tc_runtime_ecosystem"]) if toolchain_info["tc_runtime_ecosystem"] != "" else "",
     )
     matrix = VERSION_MATRIX[matrix_key]

--- a/extensions/gcc.bzl
+++ b/extensions/gcc.bzl
@@ -260,7 +260,7 @@ def _resolve_identifier(toolchain_info):
         version = toolchain_info["sdk_version"]
     elif toolchain_info["sdp_version"] != "":
         identifier = "sdp"
-        version = toolchain_info["sdp_version"]
+        version = "8.0.0" if toolchain_info["sdp_version"] == "8.0.3" else toolchain_info["sdp_version"]  # FIXME: currently we do not support constraint "8.0.3".
 
     return "{}_{}".format(identifier, version)
 

--- a/packages/version_matrix.bzl
+++ b/packages/version_matrix.bzl
@@ -73,6 +73,13 @@ VERSION_MATRIX = {
         "url": "https://www.qnx.com/download/download/79858/installation.tgz",
         "gcc_version": "12.2.0",
     },
+    "aarch64-qnx-sdp_8.0.3": {
+        "build_file": "@score_bazel_cpp_toolchains//packages/qnx/aarch64/sdp/8.0.0:sdp.BUILD",
+        "sha256": "9039fd6a4a639f06ea977afb93963a6fe8f8c46db727066709370d999c7232e0",
+        "strip_prefix": "",
+        "url": "https://www.qnx.com/download/download/87174/installation_qnx_803_260305.tar.xz",
+        "gcc_version": "12.2.0",
+    },
     "x86_64-linux-gcc_12.2.0": {
         "build_file": "@score_bazel_cpp_toolchains//packages/linux/x86_64/gcc/12.2.0:gcc.BUILD",
         "sha256": "e9b9a7a63a5f8271b76d6e2057906b95c7a244e4931a8e10edeaa241e9f7c11e",
@@ -191,6 +198,13 @@ VERSION_MATRIX = {
         "sha256": "f2e0cb21c6baddbcb65f6a70610ce498e7685de8ea2e0f1648f01b327f6bac63",
         "strip_prefix": "installation",
         "url": "https://www.qnx.com/download/download/79858/installation.tgz",
+        "gcc_version": "12.2.0",
+    },
+    "x86_64-qnx-sdp_8.0.3": {
+        "build_file": "@score_bazel_cpp_toolchains//packages/qnx/x86_64/sdp/8.0.0:sdp.BUILD",
+        "sha256": "9039fd6a4a639f06ea977afb93963a6fe8f8c46db727066709370d999c7232e0",
+        "strip_prefix": "",
+        "url": "https://www.qnx.com/download/download/87174/installation_qnx_803_260305.tar.xz",
         "gcc_version": "12.2.0",
     },
 }

--- a/rules/gcc.bzl
+++ b/rules/gcc.bzl
@@ -180,7 +180,7 @@ def _impl(rctx):
             "%{license_info_value}": rctx.attr.license_info_value,
             "%{license_info_variable}": rctx.attr.license_info_variable,
             "%{license_path}": rctx.attr.license_path,
-            "%{sdp_version}": rctx.attr.sdp_version,
+            "%{sdp_version}": "8.0.0" if rctx.attr.sdp_version == "8.0.3" else rctx.attr.sdp_version,  # FIXME: currently we do not support constraint "8.0.3".
             "%{tc_cpu_cxx}": "aarch64le" if rctx.attr.tc_cpu == "aarch64" else rctx.attr.tc_cpu,
             "%{use_license_info}": "False" if rctx.attr.license_info_value == "" else "True",
         }


### PR DESCRIPTION
The new QNX package version 8.0.3 is added. Currently we do not support this version constraint on platform side so the constraint will still point 8.0.0.