### PR TITLE
Add GNU ext. flag for c compile action.

### DIFF
--- a/templates/linux/cc_toolchain_config.bzl.template
+++ b/templates/linux/cc_toolchain_config.bzl.template
@@ -85,6 +85,9 @@ def _impl(ctx):
     dbg_feature = feature(name = "dbg")
     opt_feature = feature(name = "opt")
 
+    # Temp solution until we do not add feature injection
+    gnu11_feature = feature(name = "gnu11")
+
     supports_dynamic_linker_feature = feature(name = "supports_dynamic_linker", enabled = True)
     supports_fission_feature = feature(name = "supports_fission", enabled = True)
 
@@ -206,7 +209,13 @@ def _impl(ctx):
             ),
             flag_set(
                 actions = all_c_compile_actions,
-                flag_groups = DEFAULT_C_COMPILE_FLAGS,
+                flag_groups = [flag_group(flags = ["-std=c11"])],
+                with_features = [with_feature_set(not_features = ["gnu11"])],
+            ),
+            flag_set(
+                actions = all_c_compile_actions,
+                flag_groups = [flag_group(flags = ["-std=gnu11"])],
+                with_features = [with_feature_set(features = ["gnu11"])],
             ),
             flag_set(
                 actions = all_cpp_compile_actions,
@@ -640,6 +649,7 @@ def _impl(ctx):
         ubsan_feature,
         dbg_feature,
         unfiltered_compile_flags_feature,
+        gnu11_feature,
         default_compile_flags_feature,
         default_link_flags_feature,
         sysroot_link_flags_feature,

--- a/templates/linux/cc_toolchain_flags.bzl.template
+++ b/templates/linux/cc_toolchain_flags.bzl.template
@@ -65,7 +65,6 @@ DEFAULT_ARM64_COMPILE_FLAGS = get_flag_group([
 
 # Default compile flags for C language when no specific build type is selected.
 DEFAULT_C_COMPILE_FLAGS = get_flag_group([
-    "-std=c11",
 ])
 
 # Default compile flags for C++ language when no specific build type is selected.


### PR DESCRIPTION
Some of the libraries that we depend has to be built with gnu ext, like libopenssl. This feature ensure we can switch between them.

Issue: #46 