### PR TITLE
Linker flags reorder

### DIFF
--- a/templates/linux/cc_toolchain_flags.bzl.template
+++ b/templates/linux/cc_toolchain_flags.bzl.template
@@ -86,11 +86,15 @@ OPT_COMPILE_FLAGS = get_flag_group([
 
 # Default link flags when no specific build type is selected.
 DEFAULT_LINK_FLAGS = get_flag_group([
+    "-Wl,-Bstatic",
+    "-lstdc++",
+    "-lgcc",
+    "-lgcc_eh",
+    "-Wl,-Bdynamic",
     "-lm",
     "-ldl",
     "-lrt",
-    "-static-libstdc++",
-    "-static-libgcc",
+    "-lc",
 ])
 
 # Minimal set of warning flags to enable useful warnings without overwhelming the user.


### PR DESCRIPTION
Linker flags needed to be reorder due to issue with  link order and link grouping when using static libraries.

resolves: #53