### PR TITLE
Update library path for aarch64 toolchain

### DIFF
--- a/examples/MODULE.bazel.lock
+++ b/examples/MODULE.bazel.lock
@@ -2054,7 +2054,7 @@
     },
     "@@score_bazel_cpp_toolchains+//extensions:gcc.bzl%gcc": {
       "general": {
-        "bzlTransitiveDigest": "CMQBPgKbvivB4Ck+r1BjukX5I9fIG+1nDvljk9tx4dE=",
+        "bzlTransitiveDigest": "S3P8j4x4Dv6bMa6UG1VGbWiXBX2JINdnL5NIbj36NsA=",
         "usagesDigest": "unK8CU54SxQZb3A5+/fOy5ZHARy5jWDy5NpNfcCVyNA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/packages/version_matrix.bzl
+++ b/packages/version_matrix.bzl
@@ -52,7 +52,7 @@ VERSION_MATRIX = {
             "-L",
             "external/%{toolchain_pkg}%/lib",
             "-L",
-            "external/%{toolchain_pkg}%/usr/lib/gcc/x86_64-redhat-linux/14",
+            "external/%{toolchain_pkg}%/usr/lib/gcc/aarch64-redhat-linux/14",
             "-L",
             "external/%{toolchain_pkg}%/usr/lib64",
             "-L",


### PR DESCRIPTION
Uses correct link path for autosd aarch64