### PR TITLE
feat: add coverage support to QNX toolchain

### DIFF
--- a/examples/MODULE.bazel.lock
+++ b/examples/MODULE.bazel.lock
@@ -2054,7 +2054,7 @@
     },
     "@@score_bazel_cpp_toolchains+//extensions:gcc.bzl%gcc": {
       "general": {
-        "bzlTransitiveDigest": "iHllDaAh23UGIAhthWRzzGTXxg8CEpo6eu2u8j8xep0=",
+        "bzlTransitiveDigest": "ffZnV0q7fvKZoTuHJha11Vgfd22yTEYU3paXbuFBu2M=",
         "usagesDigest": "UGWjRneAyNFej8g6SWlPfmeiX8/dwQzCLxr5gub4nN4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/packages/qnx/aarch64/sdp/7.1.0/sdp.BUILD
+++ b/packages/qnx/aarch64/sdp/7.1.0/sdp.BUILD
@@ -69,6 +69,11 @@ filegroup(
 )
 
 filegroup(
+    name = "gcov",
+    srcs = ["host/linux/x86_64/usr/bin/aarch64-unknown-nto-qnx7.1.0-gcov"],
+)
+
+filegroup(
     name = "mkifs",
     srcs = ["host/linux/x86_64/usr/bin/mkifs"],
 )

--- a/packages/qnx/aarch64/sdp/8.0.0/sdp.BUILD
+++ b/packages/qnx/aarch64/sdp/8.0.0/sdp.BUILD
@@ -69,6 +69,11 @@ filegroup(
 )
 
 filegroup(
+    name = "gcov",
+    srcs = ["host/linux/x86_64/usr/bin/aarch64-unknown-nto-qnx8.0.0-gcov"],
+)
+
+filegroup(
     name = "mkifs",
     srcs = ["host/linux/x86_64/usr/bin/mkifs"],
 )

--- a/packages/qnx/x86_64/sdp/7.1.0/sdp.BUILD
+++ b/packages/qnx/x86_64/sdp/7.1.0/sdp.BUILD
@@ -69,6 +69,11 @@ filegroup(
 )
 
 filegroup(
+    name = "gcov",
+    srcs = ["host/linux/x86_64/usr/bin/x86_64-pc-nto-qnx7.1.0-gcov"],
+)
+
+filegroup(
     name = "mkifs",
     srcs = ["host/linux/x86_64/usr/bin/mkifs"],
 )

--- a/packages/qnx/x86_64/sdp/8.0.0/sdp.BUILD
+++ b/packages/qnx/x86_64/sdp/8.0.0/sdp.BUILD
@@ -69,6 +69,11 @@ filegroup(
 )
 
 filegroup(
+    name = "gcov",
+    srcs = ["host/linux/x86_64/usr/bin/x86_64-pc-nto-qnx8.0.0-gcov"],
+)
+
+filegroup(
     name = "mkifs",
     srcs = ["host/linux/x86_64/usr/bin/mkifs"],
 )

--- a/rules/gcc.bzl
+++ b/rules/gcc.bzl
@@ -69,6 +69,7 @@ filegroup(
     name = "all_files",
     srcs = [
         "@{tc_pkg_repo}//:all_files",
+        "gcov_wrapper",
     ]
 )
 
@@ -77,6 +78,7 @@ cc_toolchain_config(
     ar_binary = "@{tc_pkg_repo}//:ar",
     cc_binary = "@{tc_pkg_repo}//:cc",
     cxx_binary = "@{tc_pkg_repo}//:cxx",
+    gcov_binary = "@{tc_pkg_repo}//:gcov",
     strip_binary = "@{tc_pkg_repo}//:strip",
     host_dir = "@{tc_pkg_repo}//:host_dir",
     target_dir = "@{tc_pkg_repo}//:target_dir",
@@ -208,6 +210,24 @@ def _impl(rctx):
                 "%{tc_gcov_path}": "external/score_bazel_cpp_toolchains++gcc+{repo}/bin/{cpu}-unknown-linux-gnu-gcov".format(
                     repo = rctx.attr.tc_pkg_repo,
                     cpu = "aarch64le" if rctx.attr.tc_cpu == "aarch64" else rctx.attr.tc_cpu,
+                ),
+            },
+        )
+    elif rctx.attr.tc_os == "qnx":
+        # Generate gcov wrapper for QNX toolchains to enable `bazel coverage`.
+        # See: https://github.com/bazelbuild/rules_cc/issues/351
+        sdp_version = "8.0.0" if rctx.attr.sdp_version == "8.0.4" else rctx.attr.sdp_version  # FIXME: currently we do not support constraint "8.0.4".
+        if rctx.attr.tc_cpu == "aarch64":
+            gcov_triple = "aarch64-unknown-nto-qnx{sdp}".format(sdp = sdp_version)
+        else:
+            gcov_triple = "{cpu}-pc-nto-qnx{sdp}".format(cpu = rctx.attr.tc_cpu, sdp = sdp_version)
+        rctx.template(
+            "gcov_wrapper",
+            rctx.attr._cc_gcov_wrapper_script,
+            {
+                "%{tc_gcov_path}": "external/score_bazel_cpp_toolchains++gcc+{repo}/host/linux/x86_64/usr/bin/{triple}-gcov".format(
+                    repo = rctx.attr.tc_pkg_repo,
+                    triple = gcov_triple,
                 ),
             },
         )

--- a/templates/qnx/cc_toolchain_config.bzl.template
+++ b/templates/qnx/cc_toolchain_config.bzl.template
@@ -19,6 +19,7 @@ load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
     "env_entry",
     "env_set",
     "feature",
+    "feature_set",
     "flag_group",
     "flag_set",
     "tool",
@@ -424,6 +425,31 @@ def _impl(ctx):
         ],
     )
 
+    coverage_feature = feature(name = "coverage")
+    gcc_coverage_map_format_feature = feature(
+        name = "gcc_coverage_map_format",
+        provides = ["profile"],
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.preprocess_assemble,
+                ],
+                flag_groups = [flag_group(
+                    expand_if_available = "gcov_gcno_file",
+                    flags = ["-fprofile-arcs", "-ftest-coverage"],
+                )],
+            ),
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [flag_group(flags = ["-lgcov"])],
+            ),
+        ],
+        requires = [feature_set(features = ["coverage"])],
+    )
+
     # The order of the features is relevant, they are applied in this specific order.
     # A command line parameter from a feature at the end of the list will appear
     # after a command line parameter from a feature at the beginning of the list.
@@ -447,12 +473,17 @@ def _impl(ctx):
         supports_dynamic_linker_feature,
         supports_pic_feature,
         runtime_library_search_directories_feature,
+        coverage_feature,
+        gcc_coverage_map_format_feature,
     ]
 
     cxx_builtin_include_directories = [
         "/proc/self/cwd/{}".format(include_directory.path)
         for include_directory in ctx.files.cxx_builtin_include_directories
     ]
+
+    # TODO: Once https://github.com/bazelbuild/rules_cc/issues/351 is fixed remove this.
+    tool_paths = [tool_path(name = "gcov", path = "gcov_wrapper")]
 
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
@@ -467,6 +498,7 @@ def _impl(ctx):
         target_cpu =  "%{tc_cpu}",
         target_libc = "unknown",
         toolchain_identifier = "%{tc_cpu}-qnx%{sdp_version}",
+        tool_paths = tool_paths,
     )
 
 cc_toolchain_config = rule(
@@ -476,6 +508,7 @@ cc_toolchain_config = rule(
         "ar_binary": attr.label(allow_single_file = True, executable = True, cfg = "exec", mandatory = True),
         "cc_binary": attr.label(allow_single_file = True, executable = True, cfg = "exec", mandatory = True),
         "cxx_binary": attr.label(allow_single_file = True, executable = True, cfg = "exec", mandatory = True),
+        "gcov_binary": attr.label(allow_single_file = True, executable = True, cfg = "exec", mandatory = True),
         "strip_binary": attr.label(allow_single_file = True, executable = True, cfg = "exec", mandatory = True),
         "host_dir": attr.label(allow_single_file = True, mandatory = True),
         "target_dir": attr.label(allow_single_file = True, mandatory = True),


### PR DESCRIPTION
Add coverage/gcc_coverage_map_format features to QNX cc_toolchain_config template, mirroring the Linux toolchain's coverage support. This enables `bazel coverage` to instrument QNX-cross-compiled binaries.