### PR TITLE
Add QNX build and test workflow with emulated execution

### DIFF
--- a/.github/tools/qnx_credential_helper.py
+++ b/.github/tools/qnx_credential_helper.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+import http.cookiejar
+import json
+import netrc
+import os
+import sys
+import urllib.parse
+import urllib.request
+
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+
+if __name__ == "__main__":
+    data = json.load(sys.stdin)
+
+    if "qnx.com" not in data["uri"]:
+        eprint("Unsupported domain")
+        sys.exit(1)
+
+    if "SCORE_QNX_USER" in os.environ and "SCORE_QNX_PASSWORD" in os.environ:
+        login = os.environ["SCORE_QNX_USER"]
+        password = os.environ["SCORE_QNX_PASSWORD"]
+    else:
+        try:
+            nrc = netrc.netrc()
+            auth = nrc.authenticators("qnx.com")
+            if auth:
+                login, _, password = auth
+            else:
+                raise Exception("No credential found for QNX")
+        except Exception as excp:
+            eprint(excp)
+            eprint("Failed getting credentials from .netrc")
+            sys.exit(1)
+
+    data = urllib.parse.urlencode(
+        {"userlogin": login, "password": password, "UseCookie": "1"}
+    )
+    data = data.encode("ascii")
+
+    cookie_jar = http.cookiejar.CookieJar()
+    cookie_processor = urllib.request.HTTPCookieProcessor(cookie_jar)
+    opener = urllib.request.build_opener(cookie_processor)
+    urllib.request.install_opener(opener)
+
+    r = urllib.request.urlopen("https://www.qnx.com/account/login.html", data)
+    if r.status != 200:
+        eprint("Failed to login to QNX")
+        sys.exit(1)
+
+    cookies = {c.name: c.value for c in list(cookie_jar)}
+    if not "myQNX" in cookies:
+        eprint("Failed to get myQNX cookie from login page")
+        sys.exit(1)
+
+    myQNX = cookies["myQNX"]
+    print(
+        json.dumps(
+            {
+                "headers": {
+                    "Cookie": [f"myQNX={myQNX}"],
+                }
+            }
+        )
+    )

--- a/.github/workflows/qnx.yml
+++ b/.github/workflows/qnx.yml
@@ -1,0 +1,104 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+name: Bazel Build (QNX)
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  push:
+    branches:
+      - main
+  merge_group:
+    types: [checks_requested]
+  workflow_call:
+jobs:
+  qnx-build:
+    name: Build and Test ${{ matrix.bazel-config }}
+    runs-on: ${{ vars.runner_labels_ghub_standard_x64 && fromJSON(vars.runner_labels_ghub_standard_x64) || vars.REPO_RUNNER_LABELS && fromJSON(vars.REPO_RUNNER_LABELS) || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      pull-requests: read
+    # Bazel test targets live in the separate `tests` module, so run all Bazel
+    # commands from that directory. `defaults.run.working-directory` applies to
+    # `run:` steps only; `uses:` action steps still execute from the repo root.
+    defaults:
+      run:
+        working-directory: ./tests
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - bazel-config: x86_64-qnx
+            bazel-test-target: "//:all_tests"
+          - bazel-config: aarch64-qnx
+            bazel-test-target: "//:all_tests"
+            extra-bazel-test-flags: "--test_timeout=120,600,1800,7200" # Increase test timeout due to QEMU emulation
+    steps:
+      - uses: eclipse-score/more-disk-space@6a3b48901846bf7f8cc985925157d71a8973e61f # v1
+        with:
+          level: 2
+      - name: Checkout repository (Handle all events)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      - name: Setup Bazel with shared caching
+        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 #v0.19.0
+        with:
+          disk-cache: ${{ matrix.bazel-config }}
+          repository-cache: true
+          bazelisk-cache: true
+          cache-save: ${{ github.event_name == 'push' }}
+      - uses: eclipse-score/cicd-actions/unblock-user-namespace-for-linux-sandbox@30ed908edcf367bc38ebff5b386a244f9b6417a7 # 2025-06-04
+      - name: Setup QNX SDP usage
+        uses: eclipse-score/cicd-actions/setup-qnx-sdp@a2b3c36fc7d1b9d03880d19935c7ac9cfffe58c6 # 2026-05-19
+        with:
+          qnx-license: ${{ secrets.SCORE_QNX_LICENSE }}
+          qnx-user: ${{ secrets.SCORE_QNX_USER }}
+          qnx-password: ${{ secrets.SCORE_QNX_PASSWORD }}
+          qnx-credential-helper: .github/tools/qnx_credential_helper.py
+          qnx-license-dir: /opt/score_qnx/license
+      - name: Build with QNX toolchain
+        run: |
+          set -euo pipefail
+
+          bazel build --config ${{ matrix.bazel-config }} \
+            --credential_helper=*.qnx.com="${QNX_CREDENTIAL_HELPER}" -- \
+            //:all_tests
+      - name: Install qemu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system
+      - name: Enable KVM group permissions
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0660", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          sudo chown "$USER":kvm /dev/kvm && sudo chmod 0660 /dev/kvm
+      - name: Test with QNX toolchain
+        run: |
+          set -euo pipefail
+
+          bazel test --config ${{ matrix.bazel-config }} \
+            --test_output=errors \
+            --credential_helper=*.qnx.com="${QNX_CREDENTIAL_HELPER}" ${{ matrix.extra-bazel-test-flags }} -- \
+            ${{ matrix.bazel-test-target }}
+      - name: Dump test logs on failure
+        if: failure()
+        run: |
+          echo "===== Bazel test logs ====="
+          # `bazel-testlogs` is a convenience symlink in the workspace root (./tests).
+          find -L bazel-testlogs -name 'test.log' -print | while read -r log; do
+            echo ""
+            echo "----- ${log} -----"
+            cat "${log}"
+          done

--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -47,6 +47,13 @@ build:x86_64-linux-bp --extra_toolchains=@score_gcc_toolchain_bp//:x86_64-linux
 build:x86_64-qnx --config=x86_64-linux
 build:x86_64-qnx --platforms=@score_bazel_platforms//:x86_64-qnx-sdp_8.0.0-posix
 build:x86_64-qnx --extra_toolchains=@score_qcc_toolchain//:x86_64-qnx-sdp_8.0.0
+build:x86_64-qnx --extra_toolchains=@score_qnx_x86_64_ifs_toolchain//:ifs-x86_64-qnx-sdp_8.0.0
+# QNX binaries cannot run natively on the x86_64 Linux host; execute them under
+# the QNX emulator (requires qemu-system + KVM on the runner).
+test:x86_64-qnx --run_under=@score_qnx_unit_tests//src:run_under_qnx
+# Only run native (cc) test binaries under the QNX emulator. Host-side tests
+# such as the bash-script guardrail cannot execute inside the QNX VM.
+test:x86_64-qnx --test_lang_filters=cc
 
 # -------------------------------------------------------------------------------
 # Toolchain configuration for aarch64-qnx (target)
@@ -54,6 +61,13 @@ build:x86_64-qnx --extra_toolchains=@score_qcc_toolchain//:x86_64-qnx-sdp_8.0.0
 build:aarch64-qnx --config=x86_64-linux
 build:aarch64-qnx --platforms=@score_bazel_platforms//:aarch64-qnx-sdp_8.0.0-posix
 build:aarch64-qnx --extra_toolchains=@score_qcc_arm_toolchain//:aarch64-qnx-sdp_8.0.0
+build:aarch64-qnx --extra_toolchains=@score_qnx_aarch64_ifs_toolchain//:ifs-aarch64-qnx-sdp_8.0.0
+# QNX binaries cannot run natively on the x86_64 Linux host; execute them under
+# the QNX emulator (requires qemu-system + KVM on the runner).
+test:aarch64-qnx --run_under=@score_qnx_unit_tests//src:run_under_qnx
+# Only run native (cc) test binaries under the QNX emulator. Host-side tests
+# such as the bash-script guardrail cannot execute inside the QNX VM.
+test:aarch64-qnx --test_lang_filters=cc
 
 # -------------------------------------------------------------------------------
 # Toolchain configuration for aarch64-linux (target)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -63,3 +63,19 @@ test_suite(
         "//guardrails:no_legacy_features_guard_test",
     ],
 )
+
+# ============================================================================
+# Aggregate Test Suite
+#
+# Combines every test category into a single target. CI should depend on this
+# target so new tests only need to be added to the relevant suite above.
+# ============================================================================
+
+test_suite(
+    name = "all_tests",
+    tests = [
+        ":feature_verification_tests",
+        ":guardrail_tests",
+        ":language_and_standards_tests",
+    ],
+)

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -25,7 +25,7 @@ bazel_dep(name = "rules_go", version = "0.61.1")
 # *******************************************************************************
 # Common useful functions and rules for Bazel
 # *******************************************************************************
-bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
 
 # *******************************************************************************
 # Constraint values for specifying platforms and toolchains
@@ -38,6 +38,12 @@ bazel_dep(name = "score_bazel_platforms", version = "0.1.2")
 # *******************************************************************************
 bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "googletest", version = "1.17.0")
+
+# *******************************************************************************
+# QNX unit-test runner (provides //src:run_under_qnx used to execute QNX test
+# binaries under emulation via --run_under on the QNX configs).
+# *******************************************************************************
+bazel_dep(name = "score_qnx_unit_tests", version = "0.2.0", dev_dependency = True)
 
 # *******************************************************************************
 # Set dependency to Bazel C/C++ Toolchain repository - with overriding path
@@ -133,7 +139,7 @@ gcc.toolchain(
 # *******************************************************************************
 gcc.toolchain(
     name = "score_qcc_arm_toolchain",
-    sdp_version = "8.0.0",
+    sdp_version = "8.0.4",
     target_cpu = "aarch64",
     target_os = "qnx",
     use_default_package = True,
@@ -170,5 +176,38 @@ use_repo(
     "score_gcc_toolchain",
     "score_gcc_toolchain_bp",
     "score_qcc_arm_toolchain",
+    "score_qcc_arm_toolchain_pkg",
     "score_qcc_toolchain",
+    "score_qcc_toolchain_pkg",
 )
+
+# *******************************************************************************
+# Set dependency to Bazel ImageFS repository
+# *******************************************************************************
+bazel_dep(name = "score_rules_imagefs", version = "0.0.3", dev_dependency = True)
+
+# *******************************************************************************
+# Setting ImageFS toolchains (CPU:x86_64|OS:QNX|version(sdp):8.0.0)
+# *******************************************************************************
+imagefs = use_extension("@score_rules_imagefs//extensions:imagefs.bzl", "imagefs", dev_dependency = True)
+imagefs.toolchain(
+    name = "score_qnx_x86_64_ifs_toolchain",
+    sdp_to_import = "@score_qcc_toolchain_pkg",
+    sdp_version = "8.0.0",
+    target_cpu = "x86_64",
+    target_os = "qnx",
+    type = "ifs",
+)
+
+# *******************************************************************************
+# Setting ImageFS toolchains (CPU:aarch64|OS:QNX|version(sdp):8.0.0)
+# *******************************************************************************
+imagefs.toolchain(
+    name = "score_qnx_aarch64_ifs_toolchain",
+    sdp_to_import = "@score_qcc_arm_toolchain_pkg",
+    sdp_version = "8.0.0",
+    target_cpu = "aarch64",
+    target_os = "qnx",
+    type = "ifs",
+)
+use_repo(imagefs, "score_qnx_aarch64_ifs_toolchain", "score_qnx_x86_64_ifs_toolchain")

--- a/tests/MODULE.bazel.lock
+++ b/tests/MODULE.bazel.lock
@@ -66,6 +66,7 @@
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.32.0/MODULE.bazel": "095d67022a58cb20f7e20e1aefecfa65257a222c18a938e2914fd257b5f1ccdc",
+    "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
     "https://bcr.bazel.build/modules/bazel_features/1.36.0/MODULE.bazel": "596cb62090b039caf1cad1d52a8bc35cf188ca9a4e279a828005e7ee49a1bec3",
     "https://bcr.bazel.build/modules/bazel_features/1.36.0/source.json": "279625cafa5b63cc0a8ee8448d93bc5ac1431f6000c50414051173fd22a6df3c",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
@@ -88,7 +89,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/source.json": "34a3c8bcf233b835eb74be9d628899bb32999d3e0eadef1947a0a562a2b16ffb",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/MODULE.bazel": "72997b29dfd95c3fa0d0c48322d05590418edef451f8db8db5509c57875fb4b7",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/source.json": "7ad77c1e8c1b84222d9b3f3cae016a76639435744c19330b0b37c0a3c9da7dc0",
     "https://bcr.bazel.build/modules/buildifier_prebuilt/6.1.2/MODULE.bazel": "2ef4962c8b0b6d8d21928a89190755619254459bc67f870dc0ccb9ba9952d444",
     "https://bcr.bazel.build/modules/buildifier_prebuilt/6.4.0/MODULE.bazel": "37389c6b5a40c59410b4226d3bb54b08637f393d66e2fa57925c6fcf68e64bf4",
     "https://bcr.bazel.build/modules/buildifier_prebuilt/7.3.1/MODULE.bazel": "537faf0ad9f5892910074b8e43b4c91c96f1d5d86b6ed04bdbe40cf68aa48b68",
@@ -174,6 +176,7 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
     "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.14/MODULE.bazel": "353c99ed148887ee89c54a17d4100ae7e7e436593d104b668476019023b58df8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
     "https://bcr.bazel.build/modules/rules_cc/0.2.17/source.json": "3832f45d145354049137c0090df04629d9c2b5493dc5c2bf46f1834040133a07",
     "https://bcr.bazel.build/modules/rules_cc/0.2.4/MODULE.bazel": "1ff1223dfd24f3ecf8f028446d4a27608aa43c3f41e346d22838a4223980b8cc",
@@ -239,7 +242,8 @@
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
     "https://bcr.bazel.build/modules/rules_pkg/1.1.0/MODULE.bazel": "9db8031e71b6ef32d1846106e10dd0ee2deac042bd9a2de22b4761b0c3036453",
-    "https://bcr.bazel.build/modules/rules_pkg/1.1.0/source.json": "fef768df13a92ce6067e1cd0cdc47560dace01354f1d921cfb1d632511f7d608",
+    "https://bcr.bazel.build/modules/rules_pkg/1.2.0/MODULE.bazel": "c7db3c2b407e673c7a39e3625dc05dc9f12d6682cbd82a3a5924a13b491eda7e",
+    "https://bcr.bazel.build/modules/rules_pkg/1.2.0/source.json": "9062e00845bf91a4247465d371baa837adf9b6ff44c542f73ba084f07667e1dc",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
     "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
@@ -285,7 +289,8 @@
     "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
     "https://bcr.bazel.build/modules/tar.bzl/0.2.1/MODULE.bazel": "52d1c00a80a8cc67acbd01649e83d8dd6a9dc426a6c0b754a04fe8c219c76468",
     "https://bcr.bazel.build/modules/tar.bzl/0.5.1/MODULE.bazel": "7c2eb3dcfc53b0f3d6f9acdfd911ca803eaf92aadf54f8ca6e4c1f3aee288351",
-    "https://bcr.bazel.build/modules/tar.bzl/0.5.1/source.json": "deed3094f7cc779ed1d37a68403847b0e38d9dd9d931e03cb90825f3368b515f",
+    "https://bcr.bazel.build/modules/tar.bzl/0.7.0/MODULE.bazel": "cc1acd85da33c80e430b65219a620d54d114628df24a618c3a5fa0b65e988da9",
+    "https://bcr.bazel.build/modules/tar.bzl/0.7.0/source.json": "9becb80306f42d4810bfa16379fb48aad0b01ce5342bc12fe47dcd6af3ac4d7a",
     "https://bcr.bazel.build/modules/toolchain_utils/1.0.2/MODULE.bazel": "9b8be503a4fcfd3b8b952525bff0869177a5234d5c35dc3e566b9f5ca2f755a1",
     "https://bcr.bazel.build/modules/toolchain_utils/1.0.2/source.json": "88769ec576dddacafd8cca4631812cf8eead89f10a29d9405d9f7a553de6bf87",
     "https://bcr.bazel.build/modules/toolchains_protoc/0.2.1/MODULE.bazel": "2f08433ff5e659069b3a1abfee2377d68f510f2de1da50678ed992c455b4ff91",
@@ -354,6 +359,7 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.28.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.30.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.32.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.34.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.36.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.4.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_features/1.9.0/MODULE.bazel": "not found",
@@ -374,6 +380,7 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_skylib/1.7.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_skylib/1.8.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_skylib/1.8.2/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/bazel_skylib/1.9.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/buildifier_prebuilt/6.1.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/buildifier_prebuilt/6.4.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/buildifier_prebuilt/7.3.1/MODULE.bazel": "not found",
@@ -444,6 +451,7 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.0.9/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.1.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.1.5/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.2.14/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.2.17/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.2.4/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_cc/0.2.8/MODULE.bazel": "not found",
@@ -498,6 +506,7 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_pkg/0.7.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_pkg/1.0.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_pkg/1.1.0/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_pkg/1.2.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_proto/4.0.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "not found",
@@ -527,6 +536,7 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_shell/0.4.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_shell/0.5.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_shell/0.6.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_platforms/0.1.1/MODULE.bazel": "236e5bdff6f2d6de6f96cc4f5f4b1bf2cd6137547ce279668a2dd4c54cd4236c",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_platforms/0.1.2/MODULE.bazel": "d1889bf36241521c5d5c401aaf1e98242a60f9cab9d223f8190e5d7087956e83",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_platforms/0.1.2/source.json": "549c18a968c1ab76135ad38fd15981fcc04d377a62f20e2e5e0b5faa9de2b01d",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_cr_checker/0.2.2/MODULE.bazel": "dc36d9c35543db918c3fb5b93a8e684431f56c7c784cf2a1b90f35802a373c98",
@@ -559,6 +569,10 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_python_basics/0.3.1/MODULE.bazel": "99c491109937542e61df090222666a8613ef946fa7bb2b2d5ba648b2baba03ad",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_python_basics/0.3.2/MODULE.bazel": "f25490f64035a0e3a0d53ad9cb6164e8325ce6cf2a7ee68c6ae153840cb2497e",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_python_basics/0.3.4/MODULE.bazel": "53bd16dfbb1fb8ecf6822fb26f9f4e8333bac7b14d12bb02bf84078063820a31",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_qnx_unit_tests/0.2.0/MODULE.bazel": "aaffff67916dd058737aac8e04368f12b214e7646ff58adbab48e6429d1a5410",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_qnx_unit_tests/0.2.0/source.json": "c40a614fd88beab7cb65b8640debd44eff3fbc32a7839734ef1112f265d2eeef",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_rules_imagefs/0.0.3/MODULE.bazel": "d87fcd3485438284fa96d6a5a81923d6b6672468947423517cc43c4d7692ca6a",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_rules_imagefs/0.0.3/source.json": "5f2de07264fbc8f3adecffde5aea326b9f8fccf9e74fd6a057fc9c3556b00cfa",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_rust_policies/0.0.2/MODULE.bazel": "ade2bad4a331b02d9b7e7d9842e8de8c6fded6186486e02c4f7db5cd4b71d34d",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_rust_policies/0.0.2/source.json": "fbcbc738e652b0c68d5d28dd1db09f2e643dc111f5739b2f6af7ec56c2e88043",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_starpls_lsp/0.1.0/MODULE.bazel": "b2f8c4c8d8e851706255ff9002b448bff6e040b8f0c6adedbde2a09375aa16cc",
@@ -576,6 +590,7 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/stardoc/0.7.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/tar.bzl/0.2.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/tar.bzl/0.5.1/MODULE.bazel": "not found",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/tar.bzl/0.7.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/toolchain_utils/1.0.2/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/toolchains_protoc/0.2.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "not found",
@@ -1354,7 +1369,7 @@
     "@@score_bazel_cpp_toolchains+//extensions:gcc.bzl%gcc": {
       "general": {
         "bzlTransitiveDigest": "Of8FuJrUjVWLtlJvJ7FWpS+D0OMsYxR4WbF89GzvPD8=",
-        "usagesDigest": "UGWjRneAyNFej8g6SWlPfmeiX8/dwQzCLxr5gub4nN4=",
+        "usagesDigest": "1UfIz7yPBC2LyOHghQlB2yltcJXkkGH7NQITjVhleH8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1418,11 +1433,11 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://www.qnx.com/download/download/79858/installation.tgz"
+                "https://www.qnx.com/download/download/88447/installation_qnx_804_260520.tar.xz"
               ],
               "build_file": "@@score_bazel_cpp_toolchains+//packages/qnx/aarch64/sdp/8.0.0:sdp.BUILD",
-              "sha256": "f2e0cb21c6baddbcb65f6a70610ce498e7685de8ea2e0f1648f01b327f6bac63",
-              "strip_prefix": "installation"
+              "sha256": "146312c0bf22aab66e8294a06403f2ec6cfeeb074d8fa11549faffd84b7fe778",
+              "strip_prefix": ""
             }
           },
           "score_autosd_10_toolchain_pkg": {
@@ -1585,7 +1600,7 @@
               "license_info_value": "",
               "license_path": "/opt/score_qnx/license/licenses",
               "sdk_version": "",
-              "sdp_version": "8.0.0",
+              "sdp_version": "8.0.4",
               "tc_compiler_library_search_paths": [],
               "tc_cpu": "aarch64",
               "tc_identifier": "sdp_8.0.0",
@@ -1762,58 +1777,57 @@
         ]
       }
     },
-    "@@tar.bzl+//tar:extensions.bzl%toolchains": {
+    "@@score_rules_imagefs+//extensions:imagefs.bzl%imagefs": {
       "general": {
-        "bzlTransitiveDigest": "/2afh6fPjq/rcyE/jztQDK3ierehmFFngfvmqyRv72M=",
-        "usagesDigest": "maF8qsAIqeH1ey8pxP0gNZbvJt34kLZvTFeQ0ntrJVA=",
+        "bzlTransitiveDigest": "x/MeLfkCFKL5zGGdqxO8ikFOoWzlkB1VBe5tts2t0NI=",
+        "usagesDigest": "4LvOoMbWgpZh1KrPMaxsrJ/9n3DRlU6JijkThVx2Cw0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "bsd_tar_toolchains": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:toolchain.bzl%tar_toolchains_repo",
+          "score_qnx_x86_64_ifs_toolchain": {
+            "repoRuleId": "@@score_rules_imagefs+//rules/qnx:imagefs_toolchain.bzl%imagefs_toolchain",
             "attributes": {
-              "user_repository_name": "bsd_tar_toolchains"
+              "tc_cpu": "x86_64",
+              "tc_os": "qnx",
+              "tc_pkg_repo": "'@@score_bazel_cpp_toolchains++gcc+score_qcc_toolchain_pkg'",
+              "sdp_version": "8.0.0",
+              "tc_type": "ifs"
             }
           },
-          "bsd_tar_toolchains_darwin_amd64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
+          "score_qnx_aarch64_ifs_toolchain": {
+            "repoRuleId": "@@score_rules_imagefs+//rules/qnx:imagefs_toolchain.bzl%imagefs_toolchain",
             "attributes": {
-              "platform": "darwin_amd64"
-            }
-          },
-          "bsd_tar_toolchains_darwin_arm64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "darwin_arm64"
-            }
-          },
-          "bsd_tar_toolchains_linux_amd64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "linux_amd64"
-            }
-          },
-          "bsd_tar_toolchains_linux_arm64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "linux_arm64"
-            }
-          },
-          "bsd_tar_toolchains_windows_amd64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "windows_amd64"
-            }
-          },
-          "bsd_tar_toolchains_windows_arm64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "windows_arm64"
+              "tc_cpu": "aarch64",
+              "tc_os": "qnx",
+              "tc_pkg_repo": "'@@score_bazel_cpp_toolchains++gcc+score_qcc_arm_toolchain_pkg'",
+              "sdp_version": "8.0.0",
+              "tc_type": "ifs"
             }
           }
         },
-        "recordedRepoMappingEntries": []
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "score_qcc_arm_toolchain_pkg",
+            "score_bazel_cpp_toolchains++gcc+score_qcc_arm_toolchain_pkg"
+          ],
+          [
+            "",
+            "score_qcc_toolchain_pkg",
+            "score_bazel_cpp_toolchains++gcc+score_qcc_toolchain_pkg"
+          ],
+          [
+            "score_rules_imagefs+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "score_rules_imagefs+",
+            "score_rules_imagefs",
+            "score_rules_imagefs+"
+          ]
+        ]
       }
     }
   }

--- a/tests/feature_verification/BUILD
+++ b/tests/feature_verification/BUILD
@@ -113,12 +113,17 @@ cc_test(
 # Fully static linking requires static system archives (libc.a, libstdc++.a,
 # ...). The AutoSD toolchain ships only shared libraries, so the test is marked
 # incompatible with the autosd10 platform and is skipped there.
+#
+# The runtime check reads /proc/self/maps, which is Linux-specific and not
+# available on QNX, so the test is also skipped on QNX. The -static link flag
+# itself is still exercised by the build on QNX.
 cc_test(
     name = "fully_static_link_test",
     srcs = ["fully_static_link_test.cpp"],
     features = ["fully_static_link"],
     target_compatible_with = select({
         "@score_bazel_platforms//runtime_es:autosd10": ["@platforms//:incompatible"],
+        "@platforms//os:qnx": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
 )
@@ -211,7 +216,11 @@ cc_library(
     name = "pthread_test_lib",
     srcs = ["pthread_test_lib.cpp"],
     hdrs = ["pthread_test_lib.h"],
-    linkopts = ["-lpthread"],
+    # QNX bundles pthread into libc; there is no separate libpthread to link.
+    linkopts = select({
+        "@platforms//os:qnx": [],
+        "//conditions:default": ["-lpthread"],
+    }),
     linkstatic = select({
         "@score_bazel_platforms//runtime_es:ebclfsa": True,
         "//conditions:default": False,
@@ -221,6 +230,9 @@ cc_library(
 cc_test(
     name = "pthread_test",
     srcs = ["pthread_test.cpp"],
-    linkopts = ["-lpthread"],
+    linkopts = select({
+        "@platforms//os:qnx": [],
+        "//conditions:default": ["-lpthread"],
+    }),
     deps = [":pthread_test_lib"],
 )

--- a/tests/feature_verification/user_link_flags_test.cpp
+++ b/tests/feature_verification/user_link_flags_test.cpp
@@ -33,7 +33,17 @@ int main() {
     std::cout << "Testing user_link_flags feature..." << std::endl;
 
     auto marker_address = reinterpret_cast<std::uintptr_t>(&user_link_flags_marker);
+
+    // The linker's --defsym places the absolute symbol at 0x1234. In a non-PIE
+    // executable that is its exact runtime address. Position-independent
+    // executables (the QNX default) are loaded at a page-aligned base, so only
+    // the in-page offset of the symbol is guaranteed to survive; assert on that
+    // portion, which still proves the injected --defsym value propagated.
+#if defined(__QNXNTO__)
+    assert((marker_address & 0xFFF) == (0x1234 & 0xFFF));
+#else
     assert(marker_address == 0x1234);
+#endif
 
     std::cout << "user_link_flags_marker address = 0x" << std::hex << marker_address
               << std::dec << std::endl;


### PR DESCRIPTION
Introduce a GitHub Actions workflow that builds and tests the toolchains
for the x86_64-qnx and aarch64-qnx configurations, running the resulting
QNX binaries under QEMU emulation.

- Add .github/workflows/qnx.yml running a matrix build/test for both QNX
  CPU targets, setting up the QNX SDP, qemu-system and KVM, and dumping
  test logs on failure.
- Add .github/tools/qnx_credential_helper.py to authenticate QNX package
  downloads via --credential_helper.
- Wire up test execution in tests/.bazelrc: register the ImageFS
  toolchains, run cc tests under the QNX emulator (--run_under), and
  restrict QNX runs to native cc targets (--test_lang_filters=cc).
- Add an :all_tests aggregate test_suite in tests/BUILD for CI to depend
  on.
- Update tests/MODULE.bazel: add score_qnx_unit_tests and
  score_rules_imagefs dev dependencies with their ImageFS toolchains,
  bump bazel_skylib 1.8.2 -> 1.9.0, and move the aarch64 QNX SDP to
  8.0.4. Refresh MODULE.bazel.lock accordingly.
- Adjust feature tests for QNX: skip the Linux-only /proc-based
  fully_static_link_test, drop the redundant -lpthread link flag (QNX
  bundles pthread in libc), and account for PIE base addresses when
  asserting the user_link_flags --defsym marker.