### PR TITLE
Extract common explicit feature definitions into a shared module

### DIFF
--- a/extensions/gcc.bzl
+++ b/extensions/gcc.bzl
@@ -205,6 +205,7 @@ def _get_toolchains(tags):
         toolchain = {
             "cc_toolchain_config": "@score_bazel_cpp_toolchains//templates/{}:cc_toolchain_config.bzl.template".format(tag.target_os),
             "cc_toolchain_flags": "@score_bazel_cpp_toolchains//templates/{}:cc_toolchain_flags.bzl.template".format(tag.target_os),
+            "cc_toolchain_shared_features": "@score_bazel_cpp_toolchains//templates:cc_toolchain_shared_features.bzl.template",
             "gcc_version": tag.version,
             "name": tag.name,
             "use_base_constraints_only": tag.use_base_constraints_only,
@@ -417,6 +418,7 @@ def _impl(mctx):
             gcc_version = toolchain_info["gcc_version"],
             cc_toolchain_config = toolchain_info["cc_toolchain_config"],
             cc_toolchain_flags = toolchain_info["cc_toolchain_flags"],
+            cc_toolchain_shared_features = toolchain_info["cc_toolchain_shared_features"],
             use_base_constraints_only = toolchain_info["use_base_constraints_only"],
         )
 

--- a/rules/gcc.bzl
+++ b/rules/gcc.bzl
@@ -282,6 +282,12 @@ def _impl(rctx):
         {},
     )
 
+    rctx.template(
+        "shared_features.bzl",
+        rctx.attr.cc_toolchain_shared_features,
+        {},
+    )
+
     if rctx.attr.tc_os == _OS_LINUX:
         # There is an issue with gcov and cc_toolchain config.
         # See: https://github.com/bazelbuild/rules_cc/issues/351
@@ -322,6 +328,9 @@ gcc_toolchain = repository_rule(
         ),
         "cc_toolchain_flags": attr.label(
             doc = "Path to the Bazel BUILD file template for the toolchain.",
+        ),
+        "cc_toolchain_shared_features": attr.label(
+            doc = "Path to the shared features template.",
         ),
         "extra_c_compile_flags": attr.string_list(doc = "Extra/Additional C-specific compile flags."),
         "extra_compile_flags": attr.string_list(doc = "Extra/Additional compile flags."),

--- a/templates/cc_toolchain_shared_features.bzl.template
+++ b/templates/cc_toolchain_shared_features.bzl.template
@@ -1,0 +1,452 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""Shared feature definitions common to both Linux and QNX GCC toolchains (Group S)."""
+
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "feature",
+    "flag_group",
+    "flag_set",
+    "variable_with_value",
+)
+
+all_cpp_compile_actions = [
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.clif_match,
+    ACTION_NAMES.lto_backend,
+]
+
+all_c_compile_actions = [
+    ACTION_NAMES.c_compile,
+]
+
+all_assemble_actions = [
+    ACTION_NAMES.assemble,
+    ACTION_NAMES.preprocess_assemble,
+]
+
+all_compile_actions = all_c_compile_actions + all_cpp_compile_actions + all_assemble_actions
+
+all_link_actions = [
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+]
+
+all_actions = all_compile_actions + all_link_actions + [
+    ACTION_NAMES.strip,
+    ACTION_NAMES.cpp_link_static_library,
+]
+
+def make_shared_features(unfiltered_compile_flags):
+    """Construct the Group S features shared to both Linux and QNX toolchains.
+
+    These features have identical names, flag definitions, action lists, and
+    enabled state on both platforms. Callers are responsible for inserting the
+    returned features into their platform-specific features list in the correct
+    order.
+
+    Args:
+        unfiltered_compile_flags: flag_group list for the unfiltered compile
+            flags, loaded from the platform-specific flags.bzl.
+
+    Returns:
+        struct with one named field per Group S feature.
+    """
+    no_legacy_features_feature = feature(name = "no_legacy_features", enabled = True)
+
+    dbg_feature = feature(name = "dbg")
+
+    opt_feature = feature(name = "opt")
+
+    supports_dynamic_linker_feature = feature(name = "supports_dynamic_linker", enabled = True)
+
+    supports_pic_feature = feature(name = "supports_pic", enabled = True)
+
+    unfiltered_compile_flags_feature = feature(
+        name = "unfiltered_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_c_compile_actions + all_cpp_compile_actions,
+                flag_groups = unfiltered_compile_flags,
+            ),
+        ],
+    )
+
+    random_seed_feature = feature(
+        name = "random_seed",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                ],
+                flag_groups = [
+                    flag_group(
+                        expand_if_available = "output_file",
+                        flags = ["-frandom-seed=%{output_file}"],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    include_paths_feature = feature(
+        name = "include_paths",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "quote_include_paths",
+                        flags = ["-iquote", "%{quote_include_paths}"],
+                        expand_if_available = "quote_include_paths",
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "include_paths",
+                        flags = ["-I%{include_paths}"],
+                        expand_if_available = "include_paths",
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "system_include_paths",
+                        flags = ["-isystem", "%{system_include_paths}"],
+                        expand_if_available = "system_include_paths",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    preprocessor_defines_feature = feature(
+        name = "preprocessor_defines",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "preprocessor_defines",
+                        flags = ["-D%{preprocessor_defines}"],
+                        expand_if_available = "preprocessor_defines",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    user_compile_flags_feature = feature(
+        name = "user_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "user_compile_flags",
+                        flags = ["%{user_compile_flags}"],
+                        expand_if_available = "user_compile_flags",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    compiler_input_flags_feature = feature(
+        name = "compiler_input_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-c", "%{source_file}"],
+                        expand_if_available = "source_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    compiler_output_flags_feature = feature(
+        name = "compiler_output_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-S"],
+                        expand_if_available = "output_assembly_file",
+                    ),
+                    flag_group(
+                        flags = ["-E"],
+                        expand_if_available = "output_preprocess_file",
+                    ),
+                    flag_group(
+                        flags = ["-o", "%{output_file}"],
+                        expand_if_available = "output_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    pic_feature = feature(
+        name = "pic",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.cpp_module_compile,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fPIC"], expand_if_available = "pic"),
+                ],
+            ),
+        ],
+    )
+
+    archiver_flags_feature = feature(
+        name = "archiver_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(flags = ["rcsD", "%{output_execpath}"]),
+                    flag_group(
+                        iterate_over = "libraries_to_link",
+                        flag_groups = [
+                            flag_group(
+                                flags = ["%{libraries_to_link.name}"],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "object_file",
+                                ),
+                            ),
+                            flag_group(
+                                flags = ["%{libraries_to_link.object_files}"],
+                                iterate_over = "libraries_to_link.object_files",
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "object_file_group",
+                                ),
+                            ),
+                        ],
+                        expand_if_available = "libraries_to_link",
+                    ),
+                    flag_group(
+                        iterate_over = "user_archiver_flags",
+                        flags = ["%{user_archiver_flags}"],
+                        expand_if_available = "user_archiver_flags",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    user_link_flags_feature = feature(
+        name = "user_link_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "user_link_flags",
+                        flags = ["%{user_link_flags}"],
+                        expand_if_available = "user_link_flags",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    linker_param_file_feature = feature(
+        name = "linker_param_file",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions + [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(
+                        flags = ["@%{linker_param_file}"],
+                        expand_if_available = "linker_param_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    library_search_directories_feature = feature(
+        name = "library_search_directories",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "library_search_directories",
+                        flag_groups = [
+                            flag_group(
+                                flags = ["-L%{library_search_directories}"],
+                            ),
+                        ],
+                        expand_if_available = "library_search_directories",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    shared_flag_feature = feature(
+        name = "shared_flag",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                ],
+                flag_groups = [flag_group(flags = ["-shared"])],
+            ),
+        ],
+    )
+
+    output_execpath_flags_feature = feature(
+        name = "output_execpath_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-o", "%{output_execpath}"],
+                        expand_if_available = "output_execpath",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    libraries_to_link_feature = feature(
+        name = "libraries_to_link",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "libraries_to_link",
+                        flag_groups = [
+                            flag_group(
+                                flags = ["-Wl,--whole-archive", "%{libraries_to_link.name}", "-Wl,--no-whole-archive"],
+                                expand_if_true = "libraries_to_link.is_whole_archive",
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "static_library",
+                                ),
+                            ),
+                            flag_group(
+                                flags = ["%{libraries_to_link.name}"],
+                                expand_if_false = "libraries_to_link.is_whole_archive",
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "static_library",
+                                ),
+                            ),
+                            flag_group(
+                                flags = ["%{libraries_to_link.name}"],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "object_file",
+                                ),
+                            ),
+                            flag_group(
+                                flags = ["%{libraries_to_link.object_files}"],
+                                iterate_over = "libraries_to_link.object_files",
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "object_file_group",
+                                ),
+                            ),
+                            flag_group(
+                                flags = ["-l%{libraries_to_link.name}"],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "dynamic_library",
+                                ),
+                            ),
+                            flag_group(
+                                flags = ["-l:%{libraries_to_link.name}"],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "versioned_dynamic_library",
+                                ),
+                            ),
+                        ],
+                        expand_if_available = "libraries_to_link",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    return struct(
+        no_legacy_features_feature = no_legacy_features_feature,
+        dbg_feature = dbg_feature,
+        opt_feature = opt_feature,
+        supports_dynamic_linker_feature = supports_dynamic_linker_feature,
+        supports_pic_feature = supports_pic_feature,
+        unfiltered_compile_flags_feature = unfiltered_compile_flags_feature,
+        random_seed_feature = random_seed_feature,
+        include_paths_feature = include_paths_feature,
+        preprocessor_defines_feature = preprocessor_defines_feature,
+        user_compile_flags_feature = user_compile_flags_feature,
+        compiler_input_flags_feature = compiler_input_flags_feature,
+        compiler_output_flags_feature = compiler_output_flags_feature,
+        pic_feature = pic_feature,
+        archiver_flags_feature = archiver_flags_feature,
+        user_link_flags_feature = user_link_flags_feature,
+        linker_param_file_feature = linker_param_file_feature,
+        library_search_directories_feature = library_search_directories_feature,
+        shared_flag_feature = shared_flag_feature,
+        output_execpath_flags_feature = output_execpath_flags_feature,
+        libraries_to_link_feature = libraries_to_link_feature,
+    )

--- a/templates/linux/cc_toolchain_config.bzl.template
+++ b/templates/linux/cc_toolchain_config.bzl.template
@@ -51,48 +51,21 @@ load(":flags.bzl",
     "WARNINGS_AS_ERRORS",
 )
 
-all_cpp_compile_actions = [
-    ACTION_NAMES.cpp_compile,
-    ACTION_NAMES.linkstamp_compile,
-    ACTION_NAMES.cpp_header_parsing,
-    ACTION_NAMES.cpp_module_compile,
-    ACTION_NAMES.cpp_module_codegen,
-    ACTION_NAMES.clif_match,
-    ACTION_NAMES.lto_backend,
-]
-
-all_c_compile_actions = [
-    ACTION_NAMES.c_compile,
-]
-
-all_assemble_actions = [
-    ACTION_NAMES.assemble,
-    ACTION_NAMES.preprocess_assemble,
-]
-
-all_compile_actions = all_c_compile_actions + all_cpp_compile_actions + all_assemble_actions
-
-all_link_actions = [
-    ACTION_NAMES.cpp_link_executable,
-    ACTION_NAMES.cpp_link_dynamic_library,
-    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
-]
-
-all_actions = all_compile_actions + all_link_actions + [
-    ACTION_NAMES.strip,
-    ACTION_NAMES.cpp_link_static_library,
-]
+load(":shared_features.bzl",
+    "all_actions",
+    "all_assemble_actions",
+    "all_c_compile_actions",
+    "all_compile_actions",
+    "all_cpp_compile_actions",
+    "all_link_actions",
+    "make_shared_features",
+)
 
 def _impl(ctx):
-    dbg_feature = feature(name = "dbg")
-    opt_feature = feature(name = "opt")
-
-    no_legacy_features_feature = feature(name = "no_legacy_features", enabled = True)
 
     # Temp solution until we do not add feature injection
     gnu11_feature = feature(name = "gnu11")
 
-    supports_dynamic_linker_feature = feature(name = "supports_dynamic_linker", enabled = True)
     supports_fission_feature = feature(name = "supports_fission", enabled = True)
 
     assemble_action = action_config(
@@ -167,6 +140,8 @@ def _impl(ctx):
         strip_action,
     ]
 
+    shared = make_shared_features(UNFILTERED_COMPILE_FLAGS)
+
     # Set LD_LIBRARY_PATH environment variable for all actions
     # This is needed by some toolchains since these libraries are not in `rpath` of compiler binary
     # which are needed to run it.
@@ -178,17 +153,6 @@ def _impl(ctx):
             env_set(
                 actions = all_actions,
                 env_entries = [env_entry(key = "LD_LIBRARY_PATH", value = compiler_library_search_paths)] if compiler_library_search_paths != "" else [],
-            ),
-        ],
-    )
-
-    unfiltered_compile_flags_feature = feature(
-        name = "unfiltered_compile_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_c_compile_actions + all_cpp_compile_actions,
-                flag_groups = UNFILTERED_COMPILE_FLAGS
             ),
         ],
     )
@@ -426,136 +390,6 @@ def _impl(ctx):
         ],
     )
 
-    supports_pic_feature = feature(name = "supports_pic", enabled = True)
-
-    pic_feature = feature(
-        name = "pic",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.assemble,
-                    ACTION_NAMES.preprocess_assemble,
-                    ACTION_NAMES.c_compile,
-                    ACTION_NAMES.cpp_compile,
-                    ACTION_NAMES.cpp_module_codegen,
-                    ACTION_NAMES.cpp_module_compile,
-                ],
-                flag_groups = [
-                    flag_group(flags = ["-fPIC"], expand_if_available = "pic"),
-                ],
-            ),
-        ],
-    )
-
-    user_compile_flags_feature = feature(
-        name = "user_compile_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "user_compile_flags",
-                        flags = ["%{user_compile_flags}"],
-                        expand_if_available = "user_compile_flags",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    random_seed_feature = feature(
-        name = "random_seed",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.c_compile,
-                    ACTION_NAMES.cpp_compile,
-                    ACTION_NAMES.cpp_module_compile,
-                    ACTION_NAMES.cpp_module_codegen,
-                ],
-                flag_groups = [
-                    flag_group(
-                        expand_if_available = "output_file",
-                        flags = ["-frandom-seed=%{output_file}"],
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    include_paths_feature = feature(
-        name = "include_paths",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "quote_include_paths",
-                        flags = ["-iquote", "%{quote_include_paths}"],
-                        expand_if_available = "quote_include_paths",
-                    ),
-                ],
-            ),
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "include_paths",
-                        flags = ["-I%{include_paths}"],
-                        expand_if_available = "include_paths",
-                    ),
-                ],
-            ),
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "system_include_paths",
-                        flags = ["-isystem", "%{system_include_paths}"],
-                        expand_if_available = "system_include_paths",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    preprocessor_defines_feature = feature(
-        name = "preprocessor_defines",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "preprocessor_defines",
-                        flags = ["-D%{preprocessor_defines}"],
-                        expand_if_available = "preprocessor_defines",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    compiler_input_flags_feature = feature(
-        name = "compiler_input_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = ["-c", "%{source_file}"],
-                        expand_if_available = "source_file",
-                    ),
-                ],
-            ),
-        ],
-    )
-
     dependency_file_feature = feature(
         name = "dependency_file",
         enabled = True,
@@ -582,136 +416,6 @@ def _impl(ctx):
         ],
     )
 
-    compiler_output_flags_feature = feature(
-        name = "compiler_output_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = ["-S"],
-                        expand_if_available = "output_assembly_file",
-                    ),
-                    flag_group(
-                        flags = ["-E"],
-                        expand_if_available = "output_preprocess_file",
-                    ),
-                    flag_group(
-                        flags = ["-o", "%{output_file}"],
-                        expand_if_available = "output_file",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    archiver_flags_feature = feature(
-        name = "archiver_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = [ACTION_NAMES.cpp_link_static_library],
-                flag_groups = [
-                    flag_group(flags = ["rcsD", "%{output_execpath}"]),
-                    flag_group(
-                        iterate_over = "libraries_to_link",
-                        flag_groups = [
-                            flag_group(
-                                flags = ["%{libraries_to_link.name}"],
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "object_file",
-                                ),
-                            ),
-                            flag_group(
-                                flags = ["%{libraries_to_link.object_files}"],
-                                iterate_over = "libraries_to_link.object_files",
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "object_file_group",
-                                ),
-                            ),
-                        ],
-                        expand_if_available = "libraries_to_link",
-                    ),
-                    flag_group(
-                        iterate_over = "user_archiver_flags",
-                        flags = ["%{user_archiver_flags}"],
-                        expand_if_available = "user_archiver_flags",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    linker_param_file_feature = feature(
-        name = "linker_param_file",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions + [ACTION_NAMES.cpp_link_static_library],
-                flag_groups = [
-                    flag_group(
-                        flags = ["@%{linker_param_file}"],
-                        expand_if_available = "linker_param_file",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    library_search_directories_feature = feature(
-        name = "library_search_directories",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "library_search_directories",
-                        flag_groups = [
-                            flag_group(
-                                flags = ["-L%{library_search_directories}"],
-                            ),
-                        ],
-                        expand_if_available = "library_search_directories",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    shared_flag_feature = feature(
-        name = "shared_flag",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.cpp_link_dynamic_library,
-                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
-                ],
-                flag_groups = [flag_group(flags = ["-shared"])],
-            ),
-        ],
-    )
-
-    output_execpath_flags_feature = feature(
-        name = "output_execpath_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = ["-o", "%{output_execpath}"],
-                        expand_if_available = "output_execpath",
-                    ),
-                ],
-            ),
-        ],
-    )
-
     runtime_library_search_directories_feature = feature(
         name = "runtime_library_search_directories",
         enabled = True,
@@ -732,86 +436,6 @@ def _impl(ctx):
                             ),
                         ],
                         expand_if_available = "runtime_library_search_directories",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    libraries_to_link_feature = feature(
-        name = "libraries_to_link",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "libraries_to_link",
-                        flag_groups = [
-                            flag_group(
-                                flags = ["-Wl,--whole-archive", "%{libraries_to_link.name}", "-Wl,--no-whole-archive"],
-                                expand_if_true = "libraries_to_link.is_whole_archive",
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "static_library",
-                                ),
-                            ),
-                            flag_group(
-                                flags = ["%{libraries_to_link.name}"],
-                                expand_if_false = "libraries_to_link.is_whole_archive",
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "static_library",
-                                ),
-                            ),
-                            flag_group(
-                                flags = ["%{libraries_to_link.name}"],
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "object_file",
-                                ),
-                            ),
-                            flag_group(
-                                flags = ["%{libraries_to_link.object_files}"],
-                                iterate_over = "libraries_to_link.object_files",
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "object_file_group",
-                                ),
-                            ),
-                            flag_group(
-                                flags = ["-l%{libraries_to_link.name}"],
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "dynamic_library",
-                                ),
-                            ),
-                            flag_group(
-                                flags = ["-l:%{libraries_to_link.name}"],
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "versioned_dynamic_library",
-                                ),
-                            ),
-                        ],
-                        expand_if_available = "libraries_to_link",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    user_link_flags_feature = feature(
-        name = "user_link_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "user_link_flags",
-                        flags = ["%{user_link_flags}"],
-                        expand_if_available = "user_link_flags",
                     ),
                 ],
             ),
@@ -1012,30 +636,30 @@ def _impl(ctx):
     # after a command line parameter from a feature at the beginning of the list.
 
     features = [
-        no_legacy_features_feature,
+        shared.no_legacy_features_feature,
         compiler_library_search_paths_feature,
-        dbg_feature,
-        unfiltered_compile_flags_feature,
+        shared.dbg_feature,
+        shared.unfiltered_compile_flags_feature,
         gnu11_feature,
         default_compile_flags_feature,
-        random_seed_feature,
-        include_paths_feature,
-        preprocessor_defines_feature,
-        user_compile_flags_feature,
-        compiler_input_flags_feature,
-        compiler_output_flags_feature,
+        shared.random_seed_feature,
+        shared.include_paths_feature,
+        shared.preprocessor_defines_feature,
+        shared.user_compile_flags_feature,
+        shared.compiler_input_flags_feature,
+        shared.compiler_output_flags_feature,
         dependency_file_feature,
         per_object_debug_info_feature,
         includes_feature,
         default_link_flags_feature,
-        archiver_flags_feature,
-        linker_param_file_feature,
-        library_search_directories_feature,
-        shared_flag_feature,
-        output_execpath_flags_feature,
+        shared.archiver_flags_feature,
+        shared.linker_param_file_feature,
+        shared.library_search_directories_feature,
+        shared.shared_flag_feature,
+        shared.output_execpath_flags_feature,
         runtime_library_search_directories_feature,
-        libraries_to_link_feature,
-        user_link_flags_feature,
+        shared.libraries_to_link_feature,
+        shared.user_link_flags_feature,
         linkstamps_feature,
         fission_support_feature,
         force_pic_flags_feature,
@@ -1052,10 +676,10 @@ def _impl(ctx):
         extra_c_compile_flags_feature,
         extra_cxx_compile_flags_feature,
         extra_link_flags_feature,
-        opt_feature,
-        supports_dynamic_linker_feature,
-        supports_pic_feature,
-        pic_feature,
+        shared.opt_feature,
+        shared.supports_dynamic_linker_feature,
+        shared.supports_pic_feature,
+        shared.pic_feature,
         supports_header_path_normalization,
         supports_fission_feature,
         coverage_feature,
@@ -1076,7 +700,7 @@ def _impl(ctx):
     sysroot = None
     if ctx.attr.sysroot != None:
         sysroot = ctx.attr.sysroot[DefaultInfo].files.to_list()[0].path
-    
+
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
         abi_version = "%{tc_abi_version}",

--- a/templates/qnx/cc_toolchain_config.bzl.template
+++ b/templates/qnx/cc_toolchain_config.bzl.template
@@ -49,48 +49,19 @@ load(":flags.bzl",
     "WARNINGS_AS_ERRORS",
 )
 
-all_cpp_compile_actions = [
-    ACTION_NAMES.cpp_compile,
-    ACTION_NAMES.linkstamp_compile,
-    ACTION_NAMES.cpp_header_parsing,
-    ACTION_NAMES.cpp_module_compile,
-    ACTION_NAMES.cpp_module_codegen,
-    ACTION_NAMES.clif_match,
-    ACTION_NAMES.lto_backend,
-]
-
-all_c_compile_actions = [
-    ACTION_NAMES.c_compile,
-]
-
-all_assemble_actions = [
-    ACTION_NAMES.assemble,
-    ACTION_NAMES.preprocess_assemble,
-]
-
-all_compile_actions = all_c_compile_actions + all_cpp_compile_actions + all_assemble_actions
-
-all_link_actions = [
-    ACTION_NAMES.cpp_link_executable,
-    ACTION_NAMES.cpp_link_dynamic_library,
-    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
-]
-
-all_actions = all_compile_actions + all_link_actions + [
-    ACTION_NAMES.strip,
-    ACTION_NAMES.cpp_link_static_library,
-]
+load(":shared_features.bzl",
+    "all_actions",
+    "all_assemble_actions",
+    "all_c_compile_actions",
+    "all_compile_actions",
+    "all_cpp_compile_actions",
+    "all_link_actions",
+    "make_shared_features",
+)
 
 def _impl(ctx):
     """ Implementation function of GCC toolchains.
     """
-
-    dbg_feature = feature(name = "dbg")
-    opt_feature = feature(name = "opt")
-
-    no_legacy_features_feature = feature(name = "no_legacy_features", enabled = True)
-
-    supports_dynamic_linker_feature = feature(name = "supports_dynamic_linker", enabled = True)
 
     assemble_action = action_config(
         action_name = ACTION_NAMES.assemble,
@@ -164,336 +135,9 @@ def _impl(ctx):
         strip_action,
     ]
 
-    # Core compilation features
-    random_seed_feature = feature(
-        name = "random_seed",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.c_compile,
-                    ACTION_NAMES.cpp_compile,
-                    ACTION_NAMES.cpp_module_compile,
-                    ACTION_NAMES.cpp_module_codegen,
-                ],
-                flag_groups = [
-                    flag_group(
-                        expand_if_available = "output_file",
-                        flags = ["-frandom-seed=%{output_file}"],
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    include_paths_feature = feature(
-        name = "include_paths",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "quote_include_paths",
-                        flags = ["-iquote", "%{quote_include_paths}"],
-                        expand_if_available = "quote_include_paths",
-                    ),
-                ],
-            ),
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "include_paths",
-                        flags = ["-I%{include_paths}"],
-                        expand_if_available = "include_paths",
-                    ),
-                ],
-            ),
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "system_include_paths",
-                        flags = ["-isystem", "%{system_include_paths}"],
-                        expand_if_available = "system_include_paths",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    preprocessor_defines_feature = feature(
-        name = "preprocessor_defines",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "preprocessor_defines",
-                        flags = ["-D%{preprocessor_defines}"],
-                        expand_if_available = "preprocessor_defines",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    user_compile_flags_feature = feature(
-        name = "user_compile_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "user_compile_flags",
-                        flags = ["%{user_compile_flags}"],
-                        expand_if_available = "user_compile_flags",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    compiler_input_flags_feature = feature(
-        name = "compiler_input_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = ["-c", "%{source_file}"],
-                        expand_if_available = "source_file",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    compiler_output_flags_feature = feature(
-        name = "compiler_output_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = ["-S"],
-                        expand_if_available = "output_assembly_file",
-                    ),
-                    flag_group(
-                        flags = ["-E"],
-                        expand_if_available = "output_preprocess_file",
-                    ),
-                    flag_group(
-                        flags = ["-o", "%{output_file}"],
-                        expand_if_available = "output_file",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    archiver_flags_feature = feature(
-        name = "archiver_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = [ACTION_NAMES.cpp_link_static_library],
-                flag_groups = [
-                    flag_group(flags = ["rcsD", "%{output_execpath}"]),
-                    flag_group(
-                        iterate_over = "libraries_to_link",
-                        flag_groups = [
-                            flag_group(
-                                flags = ["%{libraries_to_link.name}"],
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "object_file",
-                                ),
-                            ),
-                            flag_group(
-                                flags = ["%{libraries_to_link.object_files}"],
-                                iterate_over = "libraries_to_link.object_files",
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "object_file_group",
-                                ),
-                            ),
-                        ],
-                        expand_if_available = "libraries_to_link",
-                    ),
-                    flag_group(
-                        iterate_over = "user_archiver_flags",
-                        flags = ["%{user_archiver_flags}"],
-                        expand_if_available = "user_archiver_flags",
-                    ),
-                ],
-            ),
-        ],
-    )
+    shared = make_shared_features(UNFILTERED_COMPILE_FLAGS)
 
     # Core linking features
-    user_link_flags_feature = feature(
-        name = "user_link_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "user_link_flags",
-                        flags = ["%{user_link_flags}"],
-                        expand_if_available = "user_link_flags",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    linker_param_file_feature = feature(
-        name = "linker_param_file",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions + [ACTION_NAMES.cpp_link_static_library],
-                flag_groups = [
-                    flag_group(
-                        flags = ["@%{linker_param_file}"],
-                        expand_if_available = "linker_param_file",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    library_search_directories_feature = feature(
-        name = "library_search_directories",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "library_search_directories",
-                        flag_groups = [
-                            flag_group(
-                                flags = ["-L%{library_search_directories}"],
-                            ),
-                        ],
-                        expand_if_available = "library_search_directories",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    shared_flag_feature = feature(
-        name = "shared_flag",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.cpp_link_dynamic_library,
-                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
-                ],
-                flag_groups = [flag_group(flags = ["-shared"])],
-            ),
-        ],
-    )
-
-    output_execpath_flags_feature = feature(
-        name = "output_execpath_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = ["-o", "%{output_execpath}"],
-                        expand_if_available = "output_execpath",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    libraries_to_link_feature = feature(
-        name = "libraries_to_link",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "libraries_to_link",
-                        flag_groups = [
-                            flag_group(
-                                flags = ["-Wl,--whole-archive", "%{libraries_to_link.name}", "-Wl,--no-whole-archive"],
-                                expand_if_true = "libraries_to_link.is_whole_archive",
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "static_library",
-                                ),
-                            ),
-                            flag_group(
-                                flags = ["%{libraries_to_link.name}"],
-                                expand_if_false = "libraries_to_link.is_whole_archive",
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "static_library",
-                                ),
-                            ),
-                            flag_group(
-                                flags = ["%{libraries_to_link.name}"],
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "object_file",
-                                ),
-                            ),
-                            flag_group(
-                                flags = ["%{libraries_to_link.object_files}"],
-                                iterate_over = "libraries_to_link.object_files",
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "object_file_group",
-                                ),
-                            ),
-                            flag_group(
-                                flags = ["-l%{libraries_to_link.name}"],
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "dynamic_library",
-                                ),
-                            ),
-                            flag_group(
-                                flags = ["-l:%{libraries_to_link.name}"],
-                                expand_if_equal = variable_with_value(
-                                    name = "libraries_to_link.type",
-                                    value = "versioned_dynamic_library",
-                                ),
-                            ),
-                        ],
-                        expand_if_available = "libraries_to_link",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    unfiltered_compile_flags_feature = feature(
-        name = "unfiltered_compile_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_c_compile_actions + all_cpp_compile_actions,
-                flag_groups = UNFILTERED_COMPILE_FLAGS,
-            ),
-        ],
-    )
 
     default_compile_flags_feature = feature(
         name = "default_compile_flags",
@@ -641,27 +285,6 @@ def _impl(ctx):
             ),
         ],
     )
-    supports_pic_feature = feature(name = "supports_pic", enabled = True)
-
-    pic_feature = feature(
-        name = "pic",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.assemble,
-                    ACTION_NAMES.preprocess_assemble,
-                    ACTION_NAMES.c_compile,
-                    ACTION_NAMES.cpp_compile,
-                    ACTION_NAMES.cpp_module_codegen,
-                    ACTION_NAMES.cpp_module_compile,
-                ],
-                flag_groups = [
-                    flag_group(flags = ["-fPIC"], expand_if_available = "pic"),
-                ],
-            ),
-        ],
-    )
 
     dependency_file_named_implicitly_feature = feature(
         name = "dependency_file_named_implicitly",
@@ -799,38 +422,38 @@ def _impl(ctx):
     # after a command line parameter from a feature at the beginning of the list.
 
     features = [
-        dbg_feature,
-        no_legacy_features_feature,
-        unfiltered_compile_flags_feature,
+        shared.dbg_feature,
+        shared.no_legacy_features_feature,
+        shared.unfiltered_compile_flags_feature,
         default_compile_flags_feature,
-        random_seed_feature,
-        include_paths_feature,
-        preprocessor_defines_feature,
-        user_compile_flags_feature,
-        compiler_input_flags_feature,
-        compiler_output_flags_feature,
+        shared.random_seed_feature,
+        shared.include_paths_feature,
+        shared.preprocessor_defines_feature,
+        shared.user_compile_flags_feature,
+        shared.compiler_input_flags_feature,
+        shared.compiler_output_flags_feature,
         dependency_file_named_implicitly_feature,
         dependency_file_feature,
         default_link_flags_feature,
-        archiver_flags_feature,
-        user_link_flags_feature,
-        linker_param_file_feature,
-        library_search_directories_feature,
-        shared_flag_feature,
-        output_execpath_flags_feature,
-        libraries_to_link_feature,
+        shared.archiver_flags_feature,
+        shared.user_link_flags_feature,
+        shared.linker_param_file_feature,
+        shared.library_search_directories_feature,
+        shared.shared_flag_feature,
+        shared.output_execpath_flags_feature,
+        shared.libraries_to_link_feature,
         minimal_warnings_feature,
         strict_warnings_feature,
         all_wall_warnings_feature,
         warnings_as_errors_feature,
         extra_compile_flags_feature,
         extra_link_flags_feature,
-        opt_feature,
+        shared.opt_feature,
         use_license_env_info_feautre,
         sdp_env_feature,
-        supports_dynamic_linker_feature,
-        supports_pic_feature,
-        pic_feature,
+        shared.supports_dynamic_linker_feature,
+        shared.supports_pic_feature,
+        shared.pic_feature,
         runtime_library_search_directories_feature,
         coverage_feature,
         gcc_coverage_map_format_feature,

--- a/tests/MODULE.bazel.lock
+++ b/tests/MODULE.bazel.lock
@@ -1368,7 +1368,7 @@
     },
     "@@score_bazel_cpp_toolchains+//extensions:gcc.bzl%gcc": {
       "general": {
-        "bzlTransitiveDigest": "yw9Re6dZy5Gs5l3byDyzu4qgBXBSZQbNHWm89ygsTPA=",
+        "bzlTransitiveDigest": "0RwA2lbDI6AehZIZqRcUU0TvWnT+QpHP4Ue2aP5aI8c=",
         "usagesDigest": "1UfIz7yPBC2LyOHghQlB2yltcJXkkGH7NQITjVhleH8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1486,6 +1486,7 @@
               "gcc_version": "12.2.0",
               "cc_toolchain_config": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_config.bzl.template",
               "cc_toolchain_flags": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_flags.bzl.template",
+              "cc_toolchain_shared_features": "@@score_bazel_cpp_toolchains+//templates:cc_toolchain_shared_features.bzl.template",
               "use_base_constraints_only": true
             }
           },
@@ -1513,6 +1514,7 @@
               "gcc_version": "12.2.0",
               "cc_toolchain_config": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_config.bzl.template",
               "cc_toolchain_flags": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_flags.bzl.template",
+              "cc_toolchain_shared_features": "@@score_bazel_cpp_toolchains+//templates:cc_toolchain_shared_features.bzl.template",
               "use_base_constraints_only": false
             }
           },
@@ -1540,6 +1542,7 @@
               "gcc_version": "12.2.0",
               "cc_toolchain_config": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_config.bzl.template",
               "cc_toolchain_flags": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_flags.bzl.template",
+              "cc_toolchain_shared_features": "@@score_bazel_cpp_toolchains+//templates:cc_toolchain_shared_features.bzl.template",
               "use_base_constraints_only": false
             }
           },
@@ -1569,6 +1572,7 @@
               "gcc_version": "12.2.0",
               "cc_toolchain_config": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_config.bzl.template",
               "cc_toolchain_flags": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_flags.bzl.template",
+              "cc_toolchain_shared_features": "@@score_bazel_cpp_toolchains+//templates:cc_toolchain_shared_features.bzl.template",
               "use_base_constraints_only": false
             }
           },
@@ -1596,6 +1600,7 @@
               "gcc_version": "12.2.0",
               "cc_toolchain_config": "@@score_bazel_cpp_toolchains+//templates/qnx:cc_toolchain_config.bzl.template",
               "cc_toolchain_flags": "@@score_bazel_cpp_toolchains+//templates/qnx:cc_toolchain_flags.bzl.template",
+              "cc_toolchain_shared_features": "@@score_bazel_cpp_toolchains+//templates:cc_toolchain_shared_features.bzl.template",
               "use_base_constraints_only": false
             }
           },
@@ -1623,6 +1628,7 @@
               "gcc_version": "12.2.0",
               "cc_toolchain_config": "@@score_bazel_cpp_toolchains+//templates/qnx:cc_toolchain_config.bzl.template",
               "cc_toolchain_flags": "@@score_bazel_cpp_toolchains+//templates/qnx:cc_toolchain_flags.bzl.template",
+              "cc_toolchain_shared_features": "@@score_bazel_cpp_toolchains+//templates:cc_toolchain_shared_features.bzl.template",
               "use_base_constraints_only": false
             }
           },
@@ -1686,6 +1692,7 @@
               "gcc_version": "",
               "cc_toolchain_config": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_config.bzl.template",
               "cc_toolchain_flags": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_flags.bzl.template",
+              "cc_toolchain_shared_features": "@@score_bazel_cpp_toolchains+//templates:cc_toolchain_shared_features.bzl.template",
               "use_base_constraints_only": false
             }
           },
@@ -1765,6 +1772,7 @@
               "gcc_version": "",
               "cc_toolchain_config": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_config.bzl.template",
               "cc_toolchain_flags": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_flags.bzl.template",
+              "cc_toolchain_shared_features": "@@score_bazel_cpp_toolchains+//templates:cc_toolchain_shared_features.bzl.template",
               "use_base_constraints_only": false
             }
           }


### PR DESCRIPTION
This resolves issue #85

In this commit we are taking out of linux and qnx template files the common features between those, so we no longer have those duplicated.