### PR TITLE
Create Linux specific composition layer

### DIFF
--- a/extensions/gcc.bzl
+++ b/extensions/gcc.bzl
@@ -206,6 +206,7 @@ def _get_toolchains(tags):
             "cc_toolchain_config": "@score_bazel_cpp_toolchains//templates/{}:cc_toolchain_config.bzl.template".format(tag.target_os),
             "cc_toolchain_flags": "@score_bazel_cpp_toolchains//templates/{}:cc_toolchain_flags.bzl.template".format(tag.target_os),
             "cc_toolchain_shared_features": "@score_bazel_cpp_toolchains//templates:cc_toolchain_shared_features.bzl.template",
+            "cc_toolchain_linux_features": "@score_bazel_cpp_toolchains//templates/linux:cc_toolchain_linux_features.bzl.template" if tag.target_os == "linux" else None,
             "gcc_version": tag.version,
             "name": tag.name,
             "use_base_constraints_only": tag.use_base_constraints_only,
@@ -419,6 +420,7 @@ def _impl(mctx):
             cc_toolchain_config = toolchain_info["cc_toolchain_config"],
             cc_toolchain_flags = toolchain_info["cc_toolchain_flags"],
             cc_toolchain_shared_features = toolchain_info["cc_toolchain_shared_features"],
+            cc_toolchain_linux_features = toolchain_info["cc_toolchain_linux_features"],
             use_base_constraints_only = toolchain_info["use_base_constraints_only"],
         )
 

--- a/rules/gcc.bzl
+++ b/rules/gcc.bzl
@@ -289,6 +289,14 @@ def _impl(rctx):
     )
 
     if rctx.attr.tc_os == _OS_LINUX:
+        if rctx.attr.cc_toolchain_linux_features == None:
+            fail("cc_toolchain_linux_features must be set for Linux targets")
+        rctx.template(
+            "linux_features.bzl",
+            rctx.attr.cc_toolchain_linux_features,
+            template_dict,
+        )
+
         # There is an issue with gcov and cc_toolchain config.
         # See: https://github.com/bazelbuild/rules_cc/issues/351
         rctx.template(
@@ -331,6 +339,10 @@ gcc_toolchain = repository_rule(
         ),
         "cc_toolchain_shared_features": attr.label(
             doc = "Path to the shared features template.",
+        ),
+        "cc_toolchain_linux_features": attr.label(
+            doc = "Path to the Linux-specific features template. Required for Linux targets.",
+            default = None,
         ),
         "extra_c_compile_flags": attr.string_list(doc = "Extra/Additional C-specific compile flags."),
         "extra_compile_flags": attr.string_list(doc = "Extra/Additional compile flags."),

--- a/templates/linux/cc_toolchain_config.bzl.template
+++ b/templates/linux/cc_toolchain_config.bzl.template
@@ -16,15 +16,12 @@
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
     "action_config",
-    "env_entry",
-    "env_set",
     "feature",
     "feature_set",
     "flag_group",
     "flag_set",
     "tool",
     "tool_path",
-    "variable_with_value",
     "with_feature_set",
 )
 load("@rules_cc//cc:defs.bzl", "cc_common", "CcToolchainConfigInfo")
@@ -60,13 +57,9 @@ load(":shared_features.bzl",
     "all_link_actions",
     "make_shared_features",
 )
+load(":linux_features.bzl", "make_linux_features")
 
 def _impl(ctx):
-
-    # Temp solution until we do not add feature injection
-    gnu11_feature = feature(name = "gnu11")
-
-    supports_fission_feature = feature(name = "supports_fission", enabled = True)
 
     assemble_action = action_config(
         action_name = ACTION_NAMES.assemble,
@@ -142,20 +135,7 @@ def _impl(ctx):
 
     shared = make_shared_features(UNFILTERED_COMPILE_FLAGS)
 
-    # Set LD_LIBRARY_PATH environment variable for all actions
-    # This is needed by some toolchains since these libraries are not in `rpath` of compiler binary
-    # which are needed to run it.
-    compiler_library_search_paths = "%{compiler_library_search_paths}"
-    compiler_library_search_paths_feature = feature(
-        name = "compiler_library_search_paths",
-        enabled = %{compiler_library_search_paths_switch},
-        env_sets = [
-            env_set(
-                actions = all_actions,
-                env_entries = [env_entry(key = "LD_LIBRARY_PATH", value = compiler_library_search_paths)] if compiler_library_search_paths != "" else [],
-            ),
-        ],
-    )
+    linux = make_linux_features(ctx)
 
     target_cpu_flags = []
     if ctx.attr.target_cpu == "x86_64":
@@ -203,28 +183,6 @@ def _impl(ctx):
                 ],
             ),
         ],
-    )
-
-    # Add sysroot linker flags as a separate feature (always enabled)
-    sysroot_link_flags_feature_flag_sets = []
-    if ctx.attr.sysroot != None:
-        sysroot_files = ctx.attr.sysroot[DefaultInfo].files.to_list()
-        if sysroot_files:
-            sysroot_path = sysroot_files[0].path
-            sysroot_link_flags_feature_flag_sets = [
-                flag_set(
-                    actions = all_link_actions,
-                    flag_groups = [flag_group(flags = [
-                        "--sysroot=" + sysroot_path,
-                        "-Wl,--sysroot=" + sysroot_path,
-                    ])],
-                ),
-            ]
-
-    sysroot_link_flags_feature = feature(
-        name = "sysroot_link_flags",
-        enabled = True,
-        flag_sets = sysroot_link_flags_feature_flag_sets,
     )
 
     # Only enable default link flags if extra link flags are not provided
@@ -339,32 +297,6 @@ def _impl(ctx):
         ],
     )
 
-    extra_c_compile_flags = %{extra_c_compile_flags}
-    extra_c_compile_flags_feature = feature(
-        name = "extra_c_compile_flags",
-        enabled = %{extra_c_compile_flags_switch},
-        implies = ["default_compile_flags"],
-        flag_sets = [
-            flag_set(
-                actions = all_c_compile_actions,
-                flag_groups = extra_c_compile_flags,
-            ),
-        ],
-    )
-
-    extra_cxx_compile_flags = %{extra_cxx_compile_flags}
-    extra_cxx_compile_flags_feature = feature(
-        name = "extra_cxx_compile_flags",
-        enabled = %{extra_cxx_compile_flags_switch},
-        implies = ["default_compile_flags"],
-        flag_sets = [
-            flag_set(
-                actions = all_cpp_compile_actions,
-                flag_groups = extra_cxx_compile_flags,
-            ),
-        ],
-    )
-
     extra_link_flags = %{extra_link_flags}
     extra_link_flags_feature = feature(
         name = "extra_link_flags",
@@ -373,19 +305,6 @@ def _impl(ctx):
             flag_set(
                 actions = all_link_actions,
                 flag_groups = extra_link_flags,
-            ),
-        ],
-    )
-
-    pthread_feature = feature(
-        name = "use_pthread",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [
-                    flag_group(flags = ["-pthread"]),
-                ],
             ),
         ],
     )
@@ -442,170 +361,6 @@ def _impl(ctx):
         ],
     )
 
-    # ------------------------------------------------------------------------
-    # Additional legacy features.
-    #
-    # These mirror features that Bazel's legacy toolchain machinery would add
-    # automatically. All except fully_static_link are guarded (via
-    # expand_if_available or with_features) so they are no-ops for normal builds
-    # and only emit flags when the relevant build mode is active (e.g. --fission,
-    # --force_pic, --stamp). They are therefore enabled by default.
-    #
-    # fully_static_link is left DISABLED by default because it emits -static
-    # unconditionally, which would force fully static linking for every target.
-    # Users who want it must opt in explicitly, e.g. via `--features=<name>`.
-    # ------------------------------------------------------------------------
-
-    # Fission: emit split DWARF debug info into separate .dwo files at compile.
-    per_object_debug_info_feature = feature(
-        name = "per_object_debug_info",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.assemble,
-                    ACTION_NAMES.preprocess_assemble,
-                    ACTION_NAMES.c_compile,
-                    ACTION_NAMES.cpp_compile,
-                    ACTION_NAMES.cpp_module_codegen,
-                ],
-                flag_groups = [
-                    flag_group(
-                        flags = ["-gsplit-dwarf", "-g"],
-                        expand_if_available = "per_object_debug_info_file",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    # Fission: emit a .gdb_index section at link when fission is in use.
-    fission_support_feature = feature(
-        name = "fission_support",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = ["-Wl,--gdb-index"],
-                        expand_if_available = "is_using_fission",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    # Pass linkstamp object files to the linker (used with --stamp).
-    linkstamps_feature = feature(
-        name = "linkstamps",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "linkstamp_paths",
-                        flags = ["%{linkstamp_paths}"],
-                        expand_if_available = "linkstamp_paths",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    # Force-include headers via -include (the `includes` build variable).
-    includes_feature = feature(
-        name = "includes",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [
-                    flag_group(
-                        iterate_over = "includes",
-                        flags = ["-include", "%{includes}"],
-                        expand_if_available = "includes",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    # Build position-independent executables under --force_pic.
-    force_pic_flags_feature = feature(
-        name = "force_pic_flags",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = [ACTION_NAMES.cpp_link_executable],
-                flag_groups = [
-                    flag_group(
-                        flags = ["-pie"],
-                        expand_if_available = "force_pic",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    # Strip debug symbols at link time.
-    strip_debug_symbols_feature = feature(
-        name = "strip_debug_symbols",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [
-                    flag_group(
-                        flags = ["-Wl,-S"],
-                        expand_if_available = "strip_debug_symbols",
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    # Statically link libgcc (paired with static_link_cpp_runtimes).
-    static_libgcc_feature = feature(
-        name = "static_libgcc",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.cpp_link_executable,
-                    ACTION_NAMES.cpp_link_dynamic_library,
-                ],
-                flag_groups = [flag_group(flags = ["-static-libgcc"])],
-                with_features = [
-                    with_feature_set(features = ["static_link_cpp_runtimes"]),
-                ],
-            ),
-        ],
-    )
-
-    # Fully static link (-static) under --dynamic_mode=fully.
-    fully_static_link_feature = feature(
-        name = "fully_static_link",
-        enabled = False,
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.cpp_link_executable,
-                    ACTION_NAMES.cpp_link_dynamic_library,
-                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
-                ],
-                flag_groups = [flag_group(flags = ["-static"])],
-            ),
-        ],
-    )
-
-    # Feature to disable absolute path warnings for system headers
-    supports_header_path_normalization = feature(
-        name = "supports_header_path_normalization",
-        enabled = True,
-    )
-
     coverage_feature = feature(name = "coverage")
     gcc_coverage_map_format_feature = feature(
         name = "gcc_coverage_map_format",
@@ -637,10 +392,10 @@ def _impl(ctx):
 
     features = [
         shared.no_legacy_features_feature,
-        compiler_library_search_paths_feature,
         shared.dbg_feature,
         shared.unfiltered_compile_flags_feature,
-        gnu11_feature,
+        linux.compiler_library_search_paths_feature,
+        linux.gnu11_feature,
         default_compile_flags_feature,
         shared.random_seed_feature,
         shared.include_paths_feature,
@@ -649,8 +404,8 @@ def _impl(ctx):
         shared.compiler_input_flags_feature,
         shared.compiler_output_flags_feature,
         dependency_file_feature,
-        per_object_debug_info_feature,
-        includes_feature,
+        linux.per_object_debug_info_feature,
+        linux.includes_feature,
         default_link_flags_feature,
         shared.archiver_flags_feature,
         shared.linker_param_file_feature,
@@ -660,28 +415,28 @@ def _impl(ctx):
         runtime_library_search_directories_feature,
         shared.libraries_to_link_feature,
         shared.user_link_flags_feature,
-        linkstamps_feature,
-        fission_support_feature,
-        force_pic_flags_feature,
-        strip_debug_symbols_feature,
-        static_libgcc_feature,
-        fully_static_link_feature,
-        sysroot_link_flags_feature,
-        pthread_feature,
+        linux.linkstamps_feature,
+        linux.fission_support_feature,
+        linux.force_pic_flags_feature,
+        linux.strip_debug_symbols_feature,
+        linux.static_libgcc_feature,
+        linux.fully_static_link_feature,
+        linux.sysroot_link_flags_feature,
+        linux.pthread_feature,
         minimal_warnings_feature,
         strict_warnings_feature,
         all_wall_warnings_feature,
         warnings_as_errors_feature,
         extra_compile_flags_feature,
-        extra_c_compile_flags_feature,
-        extra_cxx_compile_flags_feature,
+        linux.extra_c_compile_flags_feature,
+        linux.extra_cxx_compile_flags_feature,
         extra_link_flags_feature,
         shared.opt_feature,
         shared.supports_dynamic_linker_feature,
         shared.supports_pic_feature,
         shared.pic_feature,
-        supports_header_path_normalization,
-        supports_fission_feature,
+        linux.supports_header_path_normalization_feature,
+        linux.supports_fission_feature,
         coverage_feature,
         gcc_coverage_map_format_feature,
     ]

--- a/templates/linux/cc_toolchain_linux_features.bzl.template
+++ b/templates/linux/cc_toolchain_linux_features.bzl.template
@@ -1,0 +1,306 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""Linux-specific feature definitions for GCC toolchains (Group L)."""
+
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "env_entry",
+    "env_set",
+    "feature",
+    "flag_group",
+    "flag_set",
+    "with_feature_set",
+)
+load(
+    ":shared_features.bzl",
+    "all_actions",
+    "all_c_compile_actions",
+    "all_compile_actions",
+    "all_cpp_compile_actions",
+    "all_link_actions",
+)
+
+def make_linux_features(ctx):
+    """Construct the Group L features specific to Linux GCC toolchains.
+
+    Args:
+        ctx: Rule context, used to access sysroot attribute.
+
+    Returns:
+        struct with one named field per Group L feature.
+    """
+    # Temp solution until we do not add feature injection
+    gnu11_feature = feature(name = "gnu11")
+
+    supports_fission_feature = feature(name = "supports_fission", enabled = True)
+
+    # Set LD_LIBRARY_PATH environment variable for all actions
+    # This is needed by some toolchains since these libraries are not in `rpath` of compiler binary
+    # which are needed to run it.
+    compiler_library_search_paths = "%{compiler_library_search_paths}"
+    compiler_library_search_paths_feature = feature(
+        name = "compiler_library_search_paths",
+        enabled = %{compiler_library_search_paths_switch},
+        env_sets = [
+            env_set(
+                actions = all_actions,
+                env_entries = [env_entry(key = "LD_LIBRARY_PATH", value = compiler_library_search_paths)] if compiler_library_search_paths != "" else [],
+            ),
+        ],
+    )
+
+    # Add sysroot linker flags as a separate feature (always enabled)
+    sysroot_link_flags_feature_flag_sets = []
+    if ctx.attr.sysroot != None:
+        sysroot_files = ctx.attr.sysroot[DefaultInfo].files.to_list()
+        if sysroot_files:
+            sysroot_path = sysroot_files[0].path
+            sysroot_link_flags_feature_flag_sets = [
+                flag_set(
+                    actions = all_link_actions,
+                    flag_groups = [flag_group(flags = [
+                        "--sysroot=" + sysroot_path,
+                        "-Wl,--sysroot=" + sysroot_path,
+                    ])],
+                ),
+            ]
+
+    sysroot_link_flags_feature = feature(
+        name = "sysroot_link_flags",
+        enabled = True,
+        flag_sets = sysroot_link_flags_feature_flag_sets,
+    )
+
+    extra_c_compile_flags = %{extra_c_compile_flags}
+    extra_c_compile_flags_feature = feature(
+        name = "extra_c_compile_flags",
+        enabled = %{extra_c_compile_flags_switch},
+        implies = ["default_compile_flags"],
+        flag_sets = [
+            flag_set(
+                actions = all_c_compile_actions,
+                flag_groups = extra_c_compile_flags,
+            ),
+        ],
+    )
+
+    extra_cxx_compile_flags = %{extra_cxx_compile_flags}
+    extra_cxx_compile_flags_feature = feature(
+        name = "extra_cxx_compile_flags",
+        enabled = %{extra_cxx_compile_flags_switch},
+        implies = ["default_compile_flags"],
+        flag_sets = [
+            flag_set(
+                actions = all_cpp_compile_actions,
+                flag_groups = extra_cxx_compile_flags,
+            ),
+        ],
+    )
+
+    pthread_feature = feature(
+        name = "use_pthread",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(flags = ["-pthread"]),
+                ],
+            ),
+        ],
+    )
+
+    # ------------------------------------------------------------------------
+    # Additional legacy features.
+    #
+    # These mirror features that Bazel's legacy toolchain machinery would add
+    # automatically. All except fully_static_link are guarded (via
+    # expand_if_available or with_features) so they are no-ops for normal builds
+    # and only emit flags when the relevant build mode is active (e.g. --fission,
+    # --force_pic, --stamp). They are therefore enabled by default.
+    #
+    # fully_static_link is left DISABLED by default because it emits -static
+    # unconditionally, which would force fully static linking for every target.
+    # Users who want it must opt in explicitly, e.g. via `--features=<name>`.
+    # ------------------------------------------------------------------------
+
+    # Fission: emit split DWARF debug info into separate .dwo files at compile.
+    per_object_debug_info_feature = feature(
+        name = "per_object_debug_info",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-gsplit-dwarf", "-g"],
+                        expand_if_available = "per_object_debug_info_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    # Fission: emit a .gdb_index section at link when fission is in use.
+    fission_support_feature = feature(
+        name = "fission_support",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-Wl,--gdb-index"],
+                        expand_if_available = "is_using_fission",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    # Pass linkstamp object files to the linker (used with --stamp).
+    linkstamps_feature = feature(
+        name = "linkstamps",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "linkstamp_paths",
+                        flags = ["%{linkstamp_paths}"],
+                        expand_if_available = "linkstamp_paths",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    # Force-include headers via -include (the `includes` build variable).
+    includes_feature = feature(
+        name = "includes",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "includes",
+                        flags = ["-include", "%{includes}"],
+                        expand_if_available = "includes",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    # Build position-independent executables under --force_pic.
+    force_pic_flags_feature = feature(
+        name = "force_pic_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.cpp_link_executable],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-pie"],
+                        expand_if_available = "force_pic",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    # Strip debug symbols at link time.
+    strip_debug_symbols_feature = feature(
+        name = "strip_debug_symbols",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-Wl,-S"],
+                        expand_if_available = "strip_debug_symbols",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    # Statically link libgcc (paired with static_link_cpp_runtimes).
+    static_libgcc_feature = feature(
+        name = "static_libgcc",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                ],
+                flag_groups = [flag_group(flags = ["-static-libgcc"])],
+                with_features = [
+                    with_feature_set(features = ["static_link_cpp_runtimes"]),
+                ],
+            ),
+        ],
+    )
+
+    # Fully static link (-static) under --dynamic_mode=fully.
+    fully_static_link_feature = feature(
+        name = "fully_static_link",
+        enabled = False,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                ],
+                flag_groups = [flag_group(flags = ["-static"])],
+            ),
+        ],
+    )
+
+    # Feature to disable absolute path warnings for system headers
+    supports_header_path_normalization_feature = feature(
+        name = "supports_header_path_normalization",
+        enabled = True,
+    )
+
+    return struct(
+        supports_fission_feature = supports_fission_feature,
+        supports_header_path_normalization_feature = supports_header_path_normalization_feature,
+        compiler_library_search_paths_feature = compiler_library_search_paths_feature,
+        gnu11_feature = gnu11_feature,
+        includes_feature = includes_feature,
+        per_object_debug_info_feature = per_object_debug_info_feature,
+        sysroot_link_flags_feature = sysroot_link_flags_feature,
+        pthread_feature = pthread_feature,
+        fission_support_feature = fission_support_feature,
+        linkstamps_feature = linkstamps_feature,
+        force_pic_flags_feature = force_pic_flags_feature,
+        strip_debug_symbols_feature = strip_debug_symbols_feature,
+        static_libgcc_feature = static_libgcc_feature,
+        fully_static_link_feature = fully_static_link_feature,
+        extra_c_compile_flags_feature = extra_c_compile_flags_feature,
+        extra_cxx_compile_flags_feature = extra_cxx_compile_flags_feature,
+    )

--- a/tests/MODULE.bazel.lock
+++ b/tests/MODULE.bazel.lock
@@ -1368,7 +1368,7 @@
     },
     "@@score_bazel_cpp_toolchains+//extensions:gcc.bzl%gcc": {
       "general": {
-        "bzlTransitiveDigest": "0RwA2lbDI6AehZIZqRcUU0TvWnT+QpHP4Ue2aP5aI8c=",
+        "bzlTransitiveDigest": "t/twxIeWF+LJee/7cS9/cwXdH3lQY/KjStc0BSv99Mw=",
         "usagesDigest": "1UfIz7yPBC2LyOHghQlB2yltcJXkkGH7NQITjVhleH8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1487,6 +1487,7 @@
               "cc_toolchain_config": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_config.bzl.template",
               "cc_toolchain_flags": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_flags.bzl.template",
               "cc_toolchain_shared_features": "@@score_bazel_cpp_toolchains+//templates:cc_toolchain_shared_features.bzl.template",
+              "cc_toolchain_linux_features": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_linux_features.bzl.template",
               "use_base_constraints_only": true
             }
           },
@@ -1515,6 +1516,7 @@
               "cc_toolchain_config": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_config.bzl.template",
               "cc_toolchain_flags": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_flags.bzl.template",
               "cc_toolchain_shared_features": "@@score_bazel_cpp_toolchains+//templates:cc_toolchain_shared_features.bzl.template",
+              "cc_toolchain_linux_features": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_linux_features.bzl.template",
               "use_base_constraints_only": false
             }
           },
@@ -1543,6 +1545,7 @@
               "cc_toolchain_config": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_config.bzl.template",
               "cc_toolchain_flags": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_flags.bzl.template",
               "cc_toolchain_shared_features": "@@score_bazel_cpp_toolchains+//templates:cc_toolchain_shared_features.bzl.template",
+              "cc_toolchain_linux_features": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_linux_features.bzl.template",
               "use_base_constraints_only": false
             }
           },
@@ -1573,6 +1576,7 @@
               "cc_toolchain_config": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_config.bzl.template",
               "cc_toolchain_flags": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_flags.bzl.template",
               "cc_toolchain_shared_features": "@@score_bazel_cpp_toolchains+//templates:cc_toolchain_shared_features.bzl.template",
+              "cc_toolchain_linux_features": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_linux_features.bzl.template",
               "use_base_constraints_only": false
             }
           },
@@ -1693,6 +1697,7 @@
               "cc_toolchain_config": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_config.bzl.template",
               "cc_toolchain_flags": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_flags.bzl.template",
               "cc_toolchain_shared_features": "@@score_bazel_cpp_toolchains+//templates:cc_toolchain_shared_features.bzl.template",
+              "cc_toolchain_linux_features": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_linux_features.bzl.template",
               "use_base_constraints_only": false
             }
           },
@@ -1773,6 +1778,7 @@
               "cc_toolchain_config": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_config.bzl.template",
               "cc_toolchain_flags": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_flags.bzl.template",
               "cc_toolchain_shared_features": "@@score_bazel_cpp_toolchains+//templates:cc_toolchain_shared_features.bzl.template",
+              "cc_toolchain_linux_features": "@@score_bazel_cpp_toolchains+//templates/linux:cc_toolchain_linux_features.bzl.template",
               "use_base_constraints_only": false
             }
           }


### PR DESCRIPTION
This resolves issue https://github.com/eclipse-score/bazel_cpp_toolchains/issues/86

Creates a Linux specific composition layer, taking only into consideration the features that are referred as ["Linux-specific"](https://github.com/eclipse-score/bazel_cpp_toolchains/issues/84#issuecomment-5046189559).